### PR TITLE
Feature/use wfi cycles for mhpmcounter11

### DIFF
--- a/doc/03_reference/performance_counters.rst
+++ b/doc/03_reference/performance_counters.rst
@@ -41,7 +41,7 @@ The following events can be monitored using the performance counters of Ibex.
 +--------------+------------------+---------------------------------------------------------+
 |           10 | NumInstrRetC     | Number of compressed instructions retired               |
 +--------------+------------------+---------------------------------------------------------+
-|           11 | NumCyclesMulWait | Cycles waiting for multiply to complete                 |
+|           11 | NumCyclesWFI     | Cycles waiting in WFI instruction                       |
 +--------------+------------------+---------------------------------------------------------+
 |           12 | NumCyclesDivWait | Cycles waiting for divide to complete                   |
 +--------------+------------------+---------------------------------------------------------+
@@ -103,7 +103,7 @@ The association of events with the ``mphmcounter`` registers is hardwired as lis
 +----------------------+----------------+--------------+------------------+
 | ``mhpmcounter10(h)`` | 0xB0A (0xB8A)  |           10 | NumInstrRetC     |
 +----------------------+----------------+--------------+------------------+
-| ``mhpmcounter11(h)`` | 0xB0B (0xB8B)  |           11 | NumCyclesMulWait |
+| ``mhpmcounter11(h)`` | 0xB0B (0xB8B)  |           11 | NumCyclesWFI     |
 +----------------------+----------------+--------------+------------------+
 | ``mhpmcounter12(h)`` | 0xB0C (0xB8C)  |           12 | NumCyclesDivWait |
 +----------------------+----------------+--------------+------------------+

--- a/rtl/cve2_core.sv
+++ b/rtl/cve2_core.sv
@@ -339,7 +339,6 @@ module cve2_core import cve2_pkg::*; #(
   logic        perf_instr_ret_compressed_wb_spec;
   logic        perf_iside_wait;
   logic        perf_dside_wait;
-  logic        perf_mul_wait;
   logic        perf_wfi_wait;
   logic        perf_div_wait;
   logic        perf_jump;
@@ -632,7 +631,6 @@ module cve2_core import cve2_pkg::*; #(
     .perf_branch_o    (perf_branch),
     .perf_tbranch_o   (perf_tbranch),
     .perf_dside_wait_o(perf_dside_wait),
-    .perf_mul_wait_o  (perf_mul_wait),
     .perf_wfi_wait_o  (perf_wfi_wait),
     .perf_div_wait_o  (perf_div_wait),
     .instr_id_done_o  (instr_id_done)
@@ -1014,7 +1012,6 @@ module cve2_core import cve2_pkg::*; #(
     .mem_load_i                 (perf_load),
     .mem_store_i                (perf_store),
     .dside_wait_i               (perf_dside_wait),
-    .mul_wait_i                 (perf_mul_wait),
     .wfi_wait_i                 (perf_wfi_wait),
     .div_wait_i                 (perf_div_wait)
   );

--- a/rtl/cve2_core.sv
+++ b/rtl/cve2_core.sv
@@ -340,6 +340,7 @@ module cve2_core import cve2_pkg::*; #(
   logic        perf_iside_wait;
   logic        perf_dside_wait;
   logic        perf_mul_wait;
+  logic        perf_wfi_wait;
   logic        perf_div_wait;
   logic        perf_jump;
   logic        perf_branch;
@@ -632,6 +633,7 @@ module cve2_core import cve2_pkg::*; #(
     .perf_tbranch_o   (perf_tbranch),
     .perf_dside_wait_o(perf_dside_wait),
     .perf_mul_wait_o  (perf_mul_wait),
+    .perf_wfi_wait_o  (perf_wfi_wait),
     .perf_div_wait_o  (perf_div_wait),
     .instr_id_done_o  (instr_id_done)
   );
@@ -1013,6 +1015,7 @@ module cve2_core import cve2_pkg::*; #(
     .mem_store_i                (perf_store),
     .dside_wait_i               (perf_dside_wait),
     .mul_wait_i                 (perf_mul_wait),
+    .wfi_wait_i                 (perf_wfi_wait),
     .div_wait_i                 (perf_div_wait)
   );
 

--- a/rtl/cve2_cs_registers.sv
+++ b/rtl/cve2_cs_registers.sv
@@ -117,7 +117,7 @@ module cve2_cs_registers #(
   input  logic                 mem_load_i,                  // load from memory in this cycle
   input  logic                 mem_store_i,                 // store to memory in this cycle
   input  logic                 dside_wait_i,                // core waiting for the dside
-  input  logic                 mul_wait_i,                  // core waiting for multiply
+  input  logic                 wfi_wait_i,                  // core waiting for interrupt
   input  logic                 div_wait_i                   // core waiting for divide
 );
 
@@ -1234,7 +1234,7 @@ module cve2_cs_registers #(
     mhpmcounter_incr[8]  = branch_i;               // num of branches (conditional)
     mhpmcounter_incr[9]  = branch_taken_i;         // num of taken branches (conditional)
     mhpmcounter_incr[10] = instr_ret_compressed_i; // num of compressed instr
-    mhpmcounter_incr[11] = mul_wait_i;             // cycles waiting for multiply
+    mhpmcounter_incr[11] = wfi_wait_i;             // cycles waiting for multiply
     mhpmcounter_incr[12] = div_wait_i;             // cycles waiting for divide
   end
 

--- a/rtl/cve2_id_stage.sv
+++ b/rtl/cve2_id_stage.sv
@@ -178,7 +178,7 @@ module cve2_id_stage #(
   output logic                      perf_tbranch_o, // executing a taken branch instr
   output logic                      perf_dside_wait_o, // instruction in ID/EX is awaiting memory
                                                         // access to finish before proceeding
-  output logic                      perf_mul_wait_o,
+  output logic                      perf_wfi_wait_o,
   output logic                      perf_div_wait_o,
   output logic                      instr_id_done_o
 );
@@ -1055,7 +1055,7 @@ module cve2_id_stage #(
   // stage)
   assign en_wb_o = instr_done;
 
-  assign perf_mul_wait_o = stall_multdiv & mult_en_dec;
+  assign perf_wfi_wait_o = wfi_insn_dec;
   assign perf_div_wait_o = stall_multdiv & div_en_dec;
 
   //////////


### PR DESCRIPTION
This PR replaces the functionality behind performance counter 11 from Cycles waiting for multiply to complete to Cycles waiting in WFI instruction