### PR TITLE
Keep DbgTriggerEn and DbHwBreakNum as local params

### DIFF
--- a/doc/02_user/integration.rst
+++ b/doc/02_user/integration.rst
@@ -28,7 +28,6 @@ Instantiation Template
       .SecureIbex       ( 0                                ),
       .RndCnstLfsrSeed  ( cve2_pkg::RndCnstLfsrSeedDefault ),
       .RndCnstLfsrPerm  ( cve2_pkg::RndCnstLfsrPermDefault ),
-      .DbgTriggerEn     ( 0                                ),
       .DmHaltAddr       ( 32'h1A110800                     ),
       .DmExceptionAddr  ( 32'h1A110808                     )
   ) u_top (
@@ -139,8 +138,6 @@ Parameters
 +------------------------------+---------------------+------------+-----------------------------------------------------------------------+
 | ``RndCnstLfsrPerm``          | lfsr_perm_t         | see above  | Set the permutation applied to the output of the LFSR used to         |
 |                              |                     |            | generate dummy instructions (only relevant when SecureIbex == 1'b1)   |
-+------------------------------+---------------------+------------+-----------------------------------------------------------------------+
-| ``DbgTriggerEn``             | bit                 | 0          | Enable debug trigger support (one trigger only)                       |
 +------------------------------+---------------------+------------+-----------------------------------------------------------------------+
 | ``DmHaltAddr``               | int                 | 0x1A110800 | Address to jump to when entering Debug Mode                           |
 +------------------------------+---------------------+------------+-----------------------------------------------------------------------+

--- a/doc/03_reference/cs_registers.rst
+++ b/doc/03_reference/cs_registers.rst
@@ -340,10 +340,10 @@ CSR Address: ``0x7A0``
 
 Reset Value: ``0x0000_0000``
 
-Accessible in Debug Mode or M-Mode when trigger support is enabled (using the DbgTriggerEn parameter).
+Accessible in Debug Mode or M-Mode.
 
 Number of the currently selected trigger starting at 0.
-The number of triggers is configured by the DbgHwNumLen parameter.
+The number of triggers is 1.
 
 Writing a value larger than or equal to the number of supported triggers will write the highest valid index.
 This allows a debugger to detect the allowed number of triggers by reading back the value.
@@ -357,7 +357,7 @@ CSR Address: ``0x7A1``
 
 Reset Value: ``0x2800_1000``
 
-Accessible in Debug Mode or M-Mode when trigger support is enabled (using the DbgTriggerEn parameter).
+Accessible in Debug Mode or M-Mode.
 Since native triggers are not supported, writes to this register from M-Mode will be ignored.
 
 Ibex only implements one type of trigger, instruction address match.
@@ -413,7 +413,7 @@ CSR Address: ``0x7A2``
 
 Reset Value: ``0x0000_0000``
 
-Accessible in Debug Mode or M-Mode when trigger support is enabled (using the DbgTriggerEn parameter).
+Accessible in Debug Mode or M-Mode.
 Since native triggers are not supported, writes to this register from M-Mode will be ignored.
 
 This register stores the instruction address to match against for a breakpoint trigger.
@@ -425,7 +425,7 @@ CSR Address: ``0x7A3``
 
 Reset Value: ``0x0000_0000``
 
-Accessible in Debug Mode or M-Mode when trigger support is enabled (using the DbgTriggerEn parameter).
+Accessible in Debug Mode or M-Mode.
 
 Ibex does not support the features requiring this register, so writes are ignored and it will always read as zero.
 
@@ -436,7 +436,7 @@ CSR Address: ``0x7A8``
 
 Reset Value: ``0x0000_0000``
 
-Accessible in Debug Mode or M-Mode when trigger support is enabled (using the DbgTriggerEn parameter).
+Accessible in Debug Mode or M-Mode.
 
 Ibex does not support the features requiring this register, so writes are ignored and it will always read as zero.
 
@@ -447,7 +447,7 @@ CSR Address: ``0x7AA``
 
 Reset Value: ``0x0000_0000``
 
-Accessible in Debug Mode or M-Mode when trigger support is enabled (using the DbgTriggerEn parameter).
+Accessible in Debug Mode or M-Mode.
 
 Ibex does not support the features requiring this register, so writes are ignored and it will always read as zero.
 

--- a/doc/03_reference/debug.rst
+++ b/doc/03_reference/debug.rst
@@ -36,16 +36,11 @@ Parameters
 +---------------------+-----------------------------------------------------------------+
 | ``DmExceptionAddr`` | Address to jump to when an exception occurs while in Debug Mode |
 +---------------------+-----------------------------------------------------------------+
-| ``DbgTriggerEn``    | Enable support for debug triggers                               |
-+---------------------+-----------------------------------------------------------------+
-| ``DbgHwBreakNum``   | Number of debug triggers                                        |
-+---------------------+-----------------------------------------------------------------+
 
 Core Debug Registers
 --------------------
 
 Ibex implements four core debug registers, namely :ref:`csr-dcsr`, :ref:`csr-dpc`, and two debug scratch registers.
-If the ``DbgTriggerEn`` parameter is set, debug trigger registers are available.
-See :ref:`csr-tselect`, :ref:`csr-tdata1` and :ref:`csr-tdata2` for details.
+Debug trigger registers are available. See :ref:`csr-tselect`, :ref:`csr-tdata1` and :ref:`csr-tdata2` for details.
 All those registers are accessible from Debug Mode only.
 If software tries to access them without the core being in Debug Mode, an illegal instruction exception is triggered.

--- a/rtl/cve2_top.sv
+++ b/rtl/cve2_top.sv
@@ -24,8 +24,6 @@ module cve2_top import cve2_pkg::*; #(
   parameter bit          ICache           = 1'b0,
   parameter bit          ICacheECC        = 1'b0,
   parameter bit          BranchPredictor  = 1'b0,
-  parameter bit          DbgTriggerEn     = 1'b0,
-  parameter int unsigned DbgHwBreakNum    = 1,
   parameter bit          SecureIbex       = 1'b0,
   parameter bit          ICacheScramble   = 1'b0,
   parameter lfsr_seed_t  RndCnstLfsrSeed  = RndCnstLfsrSeedDefault,
@@ -147,6 +145,10 @@ module cve2_top import cve2_pkg::*; #(
   localparam bit          PMPEnable        = 1'b0;
   localparam int unsigned PMPGranularity   = 0;
   localparam int unsigned PMPNumRegions    = 4;
+
+  // Trigger support
+  localparam bit          DbgTriggerEn     = 1'b1;
+  localparam int unsigned DbgHwBreakNum    = 1;
 
   // Clock signals
   logic                        clk;


### PR DESCRIPTION
Signed-off-by: Szymon Bieganski <szymon.bieganski@oss.nxp.com>