### PR TITLE
[rtl] Remove unused transition in ibex_controller FSM

### DIFF
--- a/doc/03_reference/coverage_plan.rst
+++ b/doc/03_reference/coverage_plan.rst
@@ -185,7 +185,6 @@ Each pipeline stage has some associated state.
     * ``FLUSH`` -> ``DECODE`` *
     * ``FLUSH`` -> ``DBG_TAKEN_ID``
     * ``FLUSH`` -> ``WAIT_SLEEP``
-    * ``FLUSH`` -> ``IRQ_TAKEN`` *
     * ``FLUSH`` -> ``DBG_TAKEN_IF`` *
     * ``WAIT_SLEEP`` -> ``SLEEP``
     * ``SLEEP`` -> ``FIRST_FETCH``

--- a/rtl/cve2_controller.sv
+++ b/rtl/cve2_controller.sv
@@ -738,9 +738,6 @@ module cve2_controller #(
             csr_restore_dret_id_o = 1'b1;
           end else if (wfi_insn) begin
             ctrl_fsm_ns           = WAIT_SLEEP;
-          end else if (csr_pipe_flush && handle_irq) begin
-            // start handling IRQs when doing CSR-related pipeline flushes
-            ctrl_fsm_ns           = IRQ_TAKEN;
           end
         end // exc_req_q
 


### PR DESCRIPTION
When in the FLUSH state we cannot have `csr_pipe_flush` set as it depends upon `instr_executing` being set (within `ibex_id_stage`) and that is only set in the DECODE stage.