### PR TITLE
Update cve2_if_stage.sv

### DIFF
--- a/rtl/cve2_if_stage.sv
+++ b/rtl/cve2_if_stage.sv
@@ -422,7 +422,7 @@ module cve2_if_stage import cve2_pkg::*; #(
 
     logic mispredicted, mispredicted_d, mispredicted_q;
 
-    assign next_pc = fetch_addr + (instr_is_compressed_out ? 32'd2 : 32'd4);
+    assign next_pc = fetch_addr + (instr_is_compressed ? 32'd2 : 32'd4);
 
     logic predicted_branch;
 


### PR DESCRIPTION
The variable "`instr_is_compressed_out`" has been removed in a previous commit but it is still called for assign next_pc.  I replaced it with "`instr_is_compressed`" since in previous commit, 
"`instr_is_compressed_out`" was "`assign instr_is_compressed_out = insert_dummy_instr ? 1'b0 : instr_is_compressed;`".
