### PR TITLE
Update cve2_core.sv to accomodate MRET instruction

### DIFF
--- a/rtl/cve2_core.sv
+++ b/rtl/cve2_core.sv
@@ -947,8 +947,10 @@ module cve2_core import cve2_pkg::*; #(
 
   // Factor in exceptions taken in ID so RVFI tracking picks up flushed instructions that took
   // a trap
-  assign rvfi_id_done = instr_id_done | (id_stage_i.controller_i.rvfi_flush_next &
-                                         id_stage_i.controller_i.exc_req_d);
+  // MRET causes MSTATUS to get written one clock later. Fix rvfi_valid when executing MRET
+  assign rvfi_id_done = (instr_id_done & !id_stage_i.controller_i.mret_insn)|
+                         id_stage_i.csr_restore_mret_id_o |
+                        (id_stage_i.controller_i.rvfi_flush_next & id_stage_i.controller_i.exc_req_d);
 
   // Without writeback stage first RVFI stage is output stage so simply valid the cycle after
   // instruction leaves ID/EX (and so has retired)


### PR DESCRIPTION
Change the timing of rvfi_id_done to accomodate MRET instruction. The signal rvfi_valid is a single clock delayed from rvfi_id_done