### PR TITLE
Fix incorrect debug_cause priority against riscv-debug 1.0.0-STABLE

### DIFF
--- a/rtl/cve2_controller.sv
+++ b/rtl/cve2_controller.sv
@@ -532,11 +532,11 @@ module cve2_controller #(
 
         csr_save_cause_o = 1'b1;
         if (trigger_match_i) begin
-          debug_cause_o = DBG_CAUSE_TRIGGER;
-        end else if (debug_single_step_i) begin
-          debug_cause_o = DBG_CAUSE_STEP;
+          debug_cause_o = DBG_CAUSE_TRIGGER;     // (priority 4)
+        end else if (debug_req_i) begin
+          debug_cause_o = DBG_CAUSE_HALTREQ;     // (priority 1)
         end else begin
-          debug_cause_o = DBG_CAUSE_HALTREQ;
+          debug_cause_o = DBG_CAUSE_STEP;        // (priority 0, lowest)
         end
 
         // enter debug mode
@@ -680,9 +680,14 @@ module cve2_controller #(
         // Leave all other signals as is to ensure CSRs and PC get set as if
         // core was entering exception handler, entry to debug mode will then
         // see the appropriate state and setup dpc correctly.
+
         // If an EBREAK instruction is causing us to enter debug mode on the
         // same cycle as a debug_req or single step, honor the EBREAK and
-        // proceed to DBG_TAKEN_ID.
+        // proceed to DBG_TAKEN_ID, as it has the highest priority.
+        // [Debug Spec v1.0.0-STABLE, p.53]
+        // cause==EBREAK    -> prio 3 (highest)
+        // cause==debug_req -> prio 2
+        // cause==step      -> prio 1 (lowest)
         if (enter_debug_mode_prio_q && !(ebrk_insn_prio && ebreak_into_debug)) begin
           ctrl_fsm_ns = DBG_TAKEN_IF;
         end


### PR DESCRIPTION
The relevant page [Debug Spec v1.0.0-STABLE, p.53] gives the following priorities for resolving multiple concurrent reasons for entering debug mode....

DCSR.cause : Explains why Debug Mode was entered.

When there are multiple reasons to enter Debug Mode in a single cycle, hardware should set cause to the cause with the highest priority.
1: An ebreak instruction was executed.                        (priority 3)
2: A Trigger Module trigger fired with action=1.              (priority 4)
3: The debugger requested entry to Debug Mode using haltreq.  (priority 1)
4: The hart single stepped because step was set.              (priority 0, lowest)
5: The hart halted directly out of reset due to resethaltreq. (priority 2)
   It is also acceptable to report 3 when this happens.
6: The hart halted because it’s part of a halt group.         (priority 5, highest)
   Harts may report 3 for this cause instead.

Other values are reserved for future use.