### PR TITLE
 add RVFI CSRs tracing

### DIFF
--- a/rtl/cve2_core.sv
+++ b/rtl/cve2_core.sv
@@ -625,14 +625,12 @@ module cve2_core import cve2_pkg::*; #(
   assign outstanding_store_id = id_stage_i.instr_executing & id_stage_i.lsu_req_dec &
                                 id_stage_i.lsu_we;
 
-  begin : gen_no_wb_stage
-    // Without writeback stage only look into whether load or store is in ID to determine if
-    // a response is expected.
-    assign outstanding_load_resp  = outstanding_load_id;
-    assign outstanding_store_resp = outstanding_store_id;
+  // Without writeback stage only look into whether load or store is in ID to determine if
+  // a response is expected.
+  assign outstanding_load_resp  = outstanding_load_id;
+  assign outstanding_store_resp = outstanding_store_id;
 
-    `ASSERT(NoMemRFWriteWithoutPendingLoad, rf_we_lsu |-> outstanding_load_id, clk_i, !rst_ni)
-  end
+  `ASSERT(NoMemRFWriteWithoutPendingLoad, rf_we_lsu |-> outstanding_load_id, clk_i, !rst_ni)
 
   `ASSERT(NoMemResponseWithoutPendingAccess,
     data_rvalid_i |-> outstanding_load_resp | outstanding_store_resp, clk_i, !rst_ni)
@@ -1093,6 +1091,9 @@ module cve2_core import cve2_pkg::*; #(
             rvfi_ext_stage_nmi[i+1]       <= rvfi_ext_stage_nmi[i];
             rvfi_ext_stage_debug_req[i+1] <= rvfi_ext_stage_debug_req[i];
             rvfi_ext_stage_mcycle[i]      <= cs_registers_i.mcycle_counter_i.counter_val_o;
+          end
+          else begin
+            rvfi_stage_trap[i]            <= 0;
           end
         end else begin
             rvfi_stage_halt[i]      <= rvfi_stage_halt[i-1];

--- a/rtl/cve2_cs_registers.sv
+++ b/rtl/cve2_cs_registers.sv
@@ -12,6 +12,7 @@
 
 `include "prim_assert.sv"
 
+import cve2_pkg::*;
 module cve2_cs_registers #(
   parameter bit               DbgTriggerEn      = 0,
   parameter int unsigned      DbgHwBreakNum     = 1,
@@ -103,7 +104,6 @@ module cve2_cs_registers #(
   input  logic                 div_wait_i                   // core waiting for divide
 );
 
-  import cve2_pkg::*;
 
   localparam int unsigned RV32BEnabled = (RV32B == RV32BNone) ? 0 : 1;
   localparam int unsigned RV32MEnabled = (RV32M == RV32MNone) ? 0 : 1;
@@ -1444,7 +1444,83 @@ module cve2_cs_registers #(
   // CPU control register //
   //////////////////////////
 
-  // Removed
+`ifdef RVFI
+    logic [63:0] mstatus_extended_read;
+    logic [63:0] mstatus_extended_write;
+
+    assign  mstatus_extended_read[CSR_MSTATUS_MIE_BIT]                              = mstatus_q.mie;
+    assign  mstatus_extended_read[CSR_MSTATUS_MPIE_BIT]                             = mstatus_q.mpie;
+    assign  mstatus_extended_read[CSR_MSTATUS_MPP_BIT_HIGH:CSR_MSTATUS_MPP_BIT_LOW] = mstatus_q.mpp;
+    assign  mstatus_extended_read[CSR_MSTATUS_MPRV_BIT]                             = mstatus_q.mprv;
+    assign  mstatus_extended_read[CSR_MSTATUS_TW_BIT]                               = mstatus_q.tw;
+
+    assign  mstatus_extended_write[CSR_MSTATUS_MIE_BIT]                              = mstatus_d.mie;
+    assign  mstatus_extended_write[CSR_MSTATUS_MPIE_BIT]                             = mstatus_d.mpie;
+    assign  mstatus_extended_write[CSR_MSTATUS_MPP_BIT_HIGH:CSR_MSTATUS_MPP_BIT_LOW] = mstatus_d.mpp;
+    assign  mstatus_extended_write[CSR_MSTATUS_MPRV_BIT]                             = mstatus_d.mprv;
+    assign  mstatus_extended_write[CSR_MSTATUS_TW_BIT]                               = mstatus_d.tw;
+
+    wire [63:0] rvfi_csr_bypass;
+
+    assign rvfi_csr_bypass = csr_save_cause_i;
+
+    bit [63:0] rvfi_csr_addr;
+    bit [63:0] rvfi_csr_rdata;
+    bit [63:0] rvfi_csr_wdata;
+    bit [63:0] rvfi_csr_rmask;
+    bit [63:0] rvfi_csr_wmask;
+    wire [63:0] rvfi_csr_wmask_q;
+    wire [63:0] rvfi_csr_rmask_q;
+    assign rvfi_csr_if.rvfi_csr_addr =  rvfi_csr_addr;
+    assign rvfi_csr_if.rvfi_csr_rdata = rvfi_csr_rdata;
+    assign rvfi_csr_if.rvfi_csr_wdata = rvfi_csr_wdata;
+    assign rvfi_csr_if.rvfi_csr_rmask = rvfi_csr_rmask;
+    assign rvfi_csr_if.rvfi_csr_wmask = rvfi_csr_wmask;
+    assign rvfi_csr_rmask_q =  ((~csr_wr & csr_op_en_i & ~illegal_csr_insn_o)) ? -1 : 0;
+    assign rvfi_csr_wmask_q =   ((csr_wr & csr_op_en_i & ~illegal_csr_insn_o)) ? -1 : 0;
+    always @(posedge clknrst_if.clk) begin
+        rvfi_csr_addr  = csr_addr_i;
+        rvfi_csr_rdata = csr_rdata_int;
+        rvfi_csr_wdata = csr_wdata_int;
+        rvfi_csr_rmask = (rvfi_csr_rmask_q);
+        rvfi_csr_wmask = (rvfi_csr_wmask_q);
+    end
+
+`define RVFI_CONNECT(CSR_ADDR, CSR_NAME, CSR_RDATA, CSR_WDATA, CSR_RMASK, CSR_WMASK) \
+    bit [63:0] rvfi_``CSR_NAME``_csr_rdata;\
+    bit [63:0] rvfi_``CSR_NAME``_csr_wdata;\
+    bit [63:0] rvfi_``CSR_NAME``_csr_rmask;\
+    bit [63:0] rvfi_``CSR_NAME``_csr_wmask;\
+    wire [63:0] rvfi_``CSR_NAME``_csr_wmask_q; \
+    wire [63:0] rvfi_``CSR_NAME``_csr_rmask_q; \
+    assign rvfi_csr_if.rvfi_named_csr_rdata[CSR_ADDR] = (!rvfi_csr_bypass) ? rvfi_``CSR_NAME``_csr_rdata : ``CSR_RDATA``; \
+    assign rvfi_csr_if.rvfi_named_csr_wdata[CSR_ADDR] = (!rvfi_csr_bypass) ? rvfi_``CSR_NAME``_csr_wdata : ``CSR_WDATA``; \
+    assign rvfi_csr_if.rvfi_named_csr_rmask[CSR_ADDR] = (!rvfi_csr_bypass) ? rvfi_``CSR_NAME``_csr_rmask : rvfi_``CSR_NAME``_csr_rmask_q; \
+    assign rvfi_csr_if.rvfi_named_csr_wmask[CSR_ADDR] = (!rvfi_csr_bypass) ? rvfi_``CSR_NAME``_csr_wmask : rvfi_``CSR_NAME``_csr_wmask_q; \
+    assign rvfi_``CSR_NAME``_csr_rmask_q =  ((~csr_wr & csr_op_en_i & ~illegal_csr_insn_o & (csr_addr_i == CSR_ADDR)) CSR_RMASK) ? -1 : 0; \
+    assign rvfi_``CSR_NAME``_csr_wmask_q =   ((csr_wr & csr_op_en_i & ~illegal_csr_insn_o & (csr_addr_i == CSR_ADDR)) CSR_WMASK) ? -1 : 0; \
+    always @(posedge clknrst_if.clk) begin \
+        rvfi_``CSR_NAME``_csr_rdata = ``CSR_RDATA``; \
+        rvfi_``CSR_NAME``_csr_wdata = ``CSR_WDATA``; \
+        rvfi_``CSR_NAME``_csr_rmask = (rvfi_``CSR_NAME``_csr_rmask_q); \
+        rvfi_``CSR_NAME``_csr_wmask = (rvfi_``CSR_NAME``_csr_wmask_q); \
+    end
+
+   `RVFI_CONNECT( CSR_MSTATUS,          mstatus                     ,  mstatus_extended_read  , mstatus_extended_write , , || mstatus_en)
+   `RVFI_CONNECT( CSR_MIE,              mie                         ,  mie_q                  , mie_d                  , , || mie_en    )
+   `RVFI_CONNECT( CSR_MIP,              mip                         ,  mip                    , csr_wdata_i            , , )
+   `RVFI_CONNECT( CSR_MISA,             misa                        ,  MISA_VALUE             , csr_wdata_i            , ,              )
+   `RVFI_CONNECT( CSR_MTVEC,            mtvec                       ,  mtvec_q                , mtvec_d                , , || mtvec_en  )
+   `RVFI_CONNECT( CSR_MEPC,             mepc                        ,  mepc_q                 , mepc_d                 , , || mepc_en   )
+   `RVFI_CONNECT( CSR_MCAUSE,           mcause                      ,  mcause_q               , mcause_d               , , || mcause_en )
+   `RVFI_CONNECT( CSR_MTVAL,            mtval                       ,  mtval_q                , mtval_d                , , || mtval_en  )
+   `RVFI_CONNECT( CSR_MSTATUSH,         mstatush                    ,  'h0                    , csr_wdata_i            , , )
+   `RVFI_CONNECT( CSR_DCSR,             dcsr                        ,  dcsr_q                 , dcsr_d                 , , || dcsr_en)
+   `RVFI_CONNECT( CSR_DPC,              dpc                         ,  depc_q                 , depc_d                 , , || depc_en)
+   `RVFI_CONNECT( CSR_DSCRATCH0,        dscratch0                   ,  dscratch0_q            , csr_wdata_i            , , || dscratch0_en)
+   `RVFI_CONNECT( CSR_DSCRATCH1,        dscratch1                   ,  dscratch1_q            , csr_wdata_i            , , || dscratch1_en)
+
+`endif
 
   ////////////////
   // Assertions //

--- a/rtl/cve2_cs_registers.sv
+++ b/rtl/cve2_cs_registers.sv
@@ -12,7 +12,6 @@
 
 `include "prim_assert.sv"
 
-import cve2_pkg::*;
 module cve2_cs_registers #(
   parameter bit               DbgTriggerEn      = 0,
   parameter int unsigned      DbgHwBreakNum     = 1,
@@ -25,6 +24,7 @@ module cve2_cs_registers #(
   parameter cve2_pkg::rv32m_e RV32M             = cve2_pkg::RV32MFast,
   parameter cve2_pkg::rv32b_e RV32B             = cve2_pkg::RV32BNone
 ) (
+
   // Clock and Reset
   input  logic                 clk_i,
   input  logic                 rst_ni,
@@ -104,6 +104,7 @@ module cve2_cs_registers #(
   input  logic                 div_wait_i                   // core waiting for divide
 );
 
+import cve2_pkg::*;
 
   localparam int unsigned RV32BEnabled = (RV32B == RV32BNone) ? 0 : 1;
   localparam int unsigned RV32MEnabled = (RV32M == RV32MNone) ? 0 : 1;

--- a/rtl/cve2_pkg.sv
+++ b/rtl/cve2_pkg.sv
@@ -574,5 +574,85 @@ package cve2_pkg;
   // alter this to point to their system specific configuration data structure.
   localparam logic [31:0] CSR_MCONFIGPTR_VALUE = 32'b0;
 
+ // RVFI CSR element
+  typedef struct packed {
+    bit [63:0] rdata;
+    bit [63:0] rmask;
+    bit [63:0] wdata;
+    bit [63:0] wmask;
+  } rvfi_csr_elmt_t;
+
+  // RVFI CSR structure
+  typedef struct packed {
+    rvfi_csr_elmt_t fflags;
+    rvfi_csr_elmt_t frm;
+    rvfi_csr_elmt_t fcsr;
+    rvfi_csr_elmt_t ftran;
+    rvfi_csr_elmt_t dcsr;
+    rvfi_csr_elmt_t dpc;
+    rvfi_csr_elmt_t dscratch0;
+    rvfi_csr_elmt_t dscratch1;
+    rvfi_csr_elmt_t sstatus;
+    rvfi_csr_elmt_t sie;
+    rvfi_csr_elmt_t sip;
+    rvfi_csr_elmt_t stvec;
+    rvfi_csr_elmt_t scounteren;
+    rvfi_csr_elmt_t sscratch;
+    rvfi_csr_elmt_t sepc;
+    rvfi_csr_elmt_t scause;
+    rvfi_csr_elmt_t stval;
+    rvfi_csr_elmt_t satp;
+    rvfi_csr_elmt_t mstatus;
+    rvfi_csr_elmt_t mstatush;
+    rvfi_csr_elmt_t misa;
+    rvfi_csr_elmt_t medeleg;
+    rvfi_csr_elmt_t mideleg;
+    rvfi_csr_elmt_t mie;
+    rvfi_csr_elmt_t mtvec;
+    rvfi_csr_elmt_t mcounteren;
+    rvfi_csr_elmt_t mscratch;
+    rvfi_csr_elmt_t mepc;
+    rvfi_csr_elmt_t mcause;
+    rvfi_csr_elmt_t mtval;
+    rvfi_csr_elmt_t mip;
+    rvfi_csr_elmt_t menvcfg;
+    rvfi_csr_elmt_t menvcfgh;
+    rvfi_csr_elmt_t mvendorid;
+    rvfi_csr_elmt_t marchid;
+    rvfi_csr_elmt_t mhartid;
+    rvfi_csr_elmt_t mcountinhibit;
+    rvfi_csr_elmt_t mcycle;
+    rvfi_csr_elmt_t mcycleh;
+    rvfi_csr_elmt_t minstret;
+    rvfi_csr_elmt_t minstreth;
+    rvfi_csr_elmt_t cycle;
+    rvfi_csr_elmt_t cycleh;
+    rvfi_csr_elmt_t instret;
+    rvfi_csr_elmt_t instreth;
+    rvfi_csr_elmt_t dcache;
+    rvfi_csr_elmt_t icache;
+    rvfi_csr_elmt_t acc_cons;
+    rvfi_csr_elmt_t pmpcfg0;
+    rvfi_csr_elmt_t pmpcfg1;
+    rvfi_csr_elmt_t pmpcfg2;
+    rvfi_csr_elmt_t pmpcfg3;
+    rvfi_csr_elmt_t pmpaddr0;
+    rvfi_csr_elmt_t pmpaddr1;
+    rvfi_csr_elmt_t pmpaddr2;
+    rvfi_csr_elmt_t pmpaddr3;
+    rvfi_csr_elmt_t pmpaddr4;
+    rvfi_csr_elmt_t pmpaddr5;
+    rvfi_csr_elmt_t pmpaddr6;
+    rvfi_csr_elmt_t pmpaddr7;
+    rvfi_csr_elmt_t pmpaddr8;
+    rvfi_csr_elmt_t pmpaddr9;
+    rvfi_csr_elmt_t pmpaddr10;
+    rvfi_csr_elmt_t pmpaddr11;
+    rvfi_csr_elmt_t pmpaddr12;
+    rvfi_csr_elmt_t pmpaddr13;
+    rvfi_csr_elmt_t pmpaddr14;
+    rvfi_csr_elmt_t pmpaddr15;
+  } rvfi_csr_t;
+
 endpackage
 

--- a/rtl/cve2_top_tracing.sv
+++ b/rtl/cve2_top_tracing.sv
@@ -11,7 +11,6 @@ module cve2_top_tracing import cve2_pkg::*; #(
   parameter int unsigned MHPMCounterWidth = 40,
   parameter bit          RV32E            = 1'b0,
   parameter rv32m_e      RV32M            = RV32MFast,
-  parameter bit          BranchPredictor  = 1'b0,
   parameter int unsigned DmHaltAddr       = 32'h1A110800,
   parameter int unsigned DmExceptionAddr  = 32'h1A110808
 ) (
@@ -112,7 +111,6 @@ module cve2_top_tracing import cve2_pkg::*; #(
     .MHPMCounterWidth ( MHPMCounterWidth ),
     .RV32E            ( RV32E            ),
     .RV32M            ( RV32M            ),
-    .BranchPredictor  ( BranchPredictor  ),
     .DmHaltAddr       ( DmHaltAddr       ),
     .DmExceptionAddr  ( DmExceptionAddr  )
   ) u_cve2_top (


### PR DESCRIPTION
Implementation of RVFI CSRs. 

This supposes that the testbench binds a `rvfi_unified_csr_if` in the `cs_registers.sv` module.