### PR TITLE
Core-V eXtension Interface (CV-X-IF) integration

### DIFF
--- a/rtl/cve2_core.sv
+++ b/rtl/cve2_core.sv
@@ -24,7 +24,9 @@ module cve2_core import cve2_pkg::*; #(
   parameter bit          DbgTriggerEn      = 1'b0,
   parameter int unsigned DbgHwBreakNum     = 1,
   parameter int unsigned DmHaltAddr        = 32'h1A110800,
-  parameter int unsigned DmExceptionAddr   = 32'h1A110808
+  parameter int unsigned DmExceptionAddr   = 32'h1A110808,
+  parameter bit          XInterface        = 1'b0,
+  parameter [31:0]       CoprocOpcodes     = '0
 ) (
   // Clock and Reset
   input  logic                         clk_i,
@@ -53,6 +55,25 @@ module cve2_core import cve2_pkg::*; #(
   output logic [31:0]                  data_wdata_o,
   input  logic [31:0]                  data_rdata_i,
   input  logic                         data_err_i,
+
+  // Core-V Extension Interface (CV-X-IF)
+  // Issue Interface
+  output logic                         x_issue_valid_o,
+  input  logic                         x_issue_ready_i,
+  output x_issue_req_t                 x_issue_req_o,
+  input  x_issue_resp_t                x_issue_resp_i,
+  
+  // Register Interface   
+  output x_register_t                  x_register_o,
+  
+  // Commit Interface   
+  output logic                         x_commit_valid_o,
+  output x_commit_t                    x_commit_o,
+  
+  // Result Interface   
+  input  logic                         x_result_valid_i,
+  output logic                         x_result_ready_o,
+  input  x_result_t                    x_result_i,
 
   // Interrupt inputs
   input  logic                         irq_software_i,
@@ -353,7 +374,9 @@ module cve2_core import cve2_pkg::*; #(
   cve2_id_stage #(
     .RV32E          (RV32E),
     .RV32M          (RV32M),
-    .RV32B          (RV32B)
+    .RV32B          (RV32B),
+    .XInterface     (XInterface),
+    .CoprocOpcodes  (CoprocOpcodes)
   ) id_stage_i (
     .clk_i (clk_i),
     .rst_ni(rst_ni),
@@ -436,6 +459,25 @@ module cve2_core import cve2_pkg::*; #(
 
     .lsu_load_err_i (lsu_load_err),
     .lsu_store_err_i(lsu_store_err),
+
+    // Core-V Extension Interface (CV-X-IF)
+    // Issue Interface
+    .x_issue_valid_o(x_issue_valid_o),
+    .x_issue_ready_i(x_issue_ready_i),
+    .x_issue_req_o(x_issue_req_o),
+    .x_issue_resp_i(x_issue_resp_i),
+
+    // Register Interface
+    .x_register_o(x_register_o),
+
+    // Commit Interface
+    .x_commit_valid_o(x_commit_valid_o),
+    .x_commit_o(x_commit_o),
+
+    // Result Interface
+    .x_result_valid_i(x_result_valid_i),
+    .x_result_ready_o(x_result_ready_o),
+    .x_result_i(x_result_i),
 
     // Interrupt Signals
     .csr_mstatus_mie_i(csr_mstatus_mie),

--- a/rtl/cve2_core.sv
+++ b/rtl/cve2_core.sv
@@ -25,8 +25,7 @@ module cve2_core import cve2_pkg::*; #(
   parameter int unsigned DbgHwBreakNum     = 1,
   parameter int unsigned DmHaltAddr        = 32'h1A110800,
   parameter int unsigned DmExceptionAddr   = 32'h1A110808,
-  parameter bit          XInterface        = 1'b0,
-  parameter [31:0]       CoprocOpcodes     = '0
+  parameter bit          XInterface        = 1'b0
 ) (
   // Clock and Reset
   input  logic                         clk_i,
@@ -375,8 +374,7 @@ module cve2_core import cve2_pkg::*; #(
     .RV32E          (RV32E),
     .RV32M          (RV32M),
     .RV32B          (RV32B),
-    .XInterface     (XInterface),
-    .CoprocOpcodes  (CoprocOpcodes)
+    .XInterface     (XInterface)
   ) id_stage_i (
     .clk_i (clk_i),
     .rst_ni(rst_ni),

--- a/rtl/cve2_decoder.sv
+++ b/rtl/cve2_decoder.sv
@@ -16,7 +16,9 @@
 module cve2_decoder #(
   parameter bit RV32E               = 0,
   parameter cve2_pkg::rv32m_e RV32M = cve2_pkg::RV32MFast,
-  parameter cve2_pkg::rv32b_e RV32B = cve2_pkg::RV32BNone
+  parameter cve2_pkg::rv32b_e RV32B = cve2_pkg::RV32BNone,
+  parameter bit               XInterface    = 1'b0,
+  parameter [31:0]            CoprocOpcodes = '0
 ) (
   input  logic                 clk_i,
   input  logic                 rst_ni,
@@ -50,46 +52,51 @@ module cve2_decoder #(
   output logic [31:0]           zimm_rs1_type_o,
 
   // register file
-  output cve2_pkg::rf_wd_sel_e rf_wdata_sel_o,   // RF write data selection
-  output logic                 rf_we_o,          // write enable for regfile
-  output logic [4:0]           rf_raddr_a_o,
-  output logic [4:0]           rf_raddr_b_o,
-  output logic [4:0]           rf_waddr_o,
-  output logic                 rf_ren_a_o,          // Instruction reads from RF addr A
-  output logic                 rf_ren_b_o,          // Instruction reads from RF addr B
-
-  // ALU
-  output cve2_pkg::alu_op_e    alu_operator_o,        // ALU operation selection
-  output cve2_pkg::op_a_sel_e  alu_op_a_mux_sel_o,    // operand a selection: reg value, PC,
-                                                      // immediate or zero
-  output cve2_pkg::op_b_sel_e  alu_op_b_mux_sel_o,    // operand b selection: reg value or
-                                                      // immediate
-  output logic                 alu_multicycle_o,      // ternary bitmanip instruction
-
-  // MULT & DIV
-  output logic                 mult_en_o,             // perform integer multiplication
-  output logic                 div_en_o,              // perform integer division or remainder
-  output logic                 mult_sel_o,            // as above but static, for data muxes
-  output logic                 div_sel_o,             // as above but static, for data muxes
-
-  output cve2_pkg::md_op_e     multdiv_operator_o,
-  output logic [1:0]           multdiv_signed_mode_o,
-
-  // CSRs
-  output logic                 csr_access_o,          // access to CSR
-  output cve2_pkg::csr_op_e    csr_op_o,              // operation to perform on CSR
-
-  // LSU
-  output logic                 data_req_o,            // start transaction to data memory
-  output logic                 data_we_o,             // write enable
-  output logic [1:0]           data_type_o,           // size of transaction: byte, half
-                                                      // word or word
-  output logic                 data_sign_extension_o, // sign extension for data read from
+  output cve2_pkg::rf_wd_sel_e     rf_wdata_sel_o,   // RF write data selection
+  output logic                     rf_we_o,          // write enable for regfile
+  output logic [4:0]               rf_raddr_a_o,
+  output logic [4:0]               rf_raddr_b_o,
+  output logic [4:0]               rf_waddr_o,
+  output logic                     rf_ren_a_o,          // Instruction reads from RF addr A
+  output logic                     rf_ren_b_o,          // Instruction reads from RF addr B
+    
+  // ALU    
+  output cve2_pkg::alu_op_e        alu_operator_o,        // ALU operation selection
+  output cve2_pkg::op_a_sel_e      alu_op_a_mux_sel_o,    // operand a selection: reg value, PC,
+                                                          // immediate or zero
+  output cve2_pkg::op_b_sel_e      alu_op_b_mux_sel_o,    // operand b selection: reg value or
+                                                          // immediate
+  output logic                     alu_multicycle_o,      // ternary bitmanip instruction
+    
+  // MULT & DIV    
+  output logic                     mult_en_o,             // perform integer multiplication
+  output logic                     div_en_o,              // perform integer division or remainder
+  output logic                     mult_sel_o,            // as above but static, for data muxes
+  output logic                     div_sel_o,             // as above but static, for data muxes
+    
+  output cve2_pkg::md_op_e         multdiv_operator_o,
+  output logic [1:0]               multdiv_signed_mode_o,
+    
+  // CSRs    
+  output logic                     csr_access_o,          // access to CSR
+  output cve2_pkg::csr_op_e        csr_op_o,              // operation to perform on CSR
+    
+  // LSU    
+  output logic                     data_req_o,            // start transaction to data memory
+  output logic                     data_we_o,             // write enable
+  output logic [1:0]               data_type_o,           // size of transaction: byte, half
+                                                          // word or word
+  output logic                     data_sign_extension_o, // sign extension for data read from
                                                       // memory
 
+  // Core-V eXtension interface (CV-X-IF)
+  input  cve2_pkg::readregflags_t  x_issue_resp_register_read_i,
+  input  cve2_pkg::writeregflags_t x_issue_resp_writeback_i,
+  output logic                     coproc_instr_in_dec_o,
+
   // jump/branches
-  output logic                 jump_in_dec_o,         // jump is being calculated in ALU
-  output logic                 branch_in_dec_o
+  output logic                     jump_in_dec_o,         // jump is being calculated in ALU
+  output logic                     branch_in_dec_o
 );
 
   import cve2_pkg::*;
@@ -201,6 +208,7 @@ module cve2_decoder #(
     jump_in_dec_o         = 1'b0;
     jump_set_o            = 1'b0;
     branch_in_dec_o       = 1'b0;
+    coproc_instr_in_dec_o = 1'b0; 
 
     multdiv_operator_o    = MD_OP_MULL;
     multdiv_signed_mode_o = 2'b00;
@@ -632,6 +640,17 @@ module cve2_decoder #(
       end
       default: begin
         illegal_insn = 1'b1;
+
+        for(int i = 0; i < 32; i++) begin
+          if(XInterface && CoprocOpcodes[i] && (instr[6:2] == i)) begin
+            coproc_instr_in_dec_o = 1'b1;
+            rf_ren_a_o            = x_issue_resp_register_read_i[0];     
+            rf_ren_b_o            = x_issue_resp_register_read_i[1];           
+            rf_we                 = x_issue_resp_register_read_i;                          
+            rf_wdata_sel_o        = RF_WD_COPROC;
+            illegal_insn          = 1'b0;
+          end
+        end
       end
     endcase
 

--- a/rtl/cve2_id_stage.sv
+++ b/rtl/cve2_id_stage.sv
@@ -20,7 +20,9 @@
 module cve2_id_stage #(
   parameter bit               RV32E           = 0,
   parameter cve2_pkg::rv32m_e RV32M           = cve2_pkg::RV32MFast,
-  parameter cve2_pkg::rv32b_e RV32B           = cve2_pkg::RV32BNone
+  parameter cve2_pkg::rv32b_e RV32B           = cve2_pkg::RV32BNone,
+  parameter bit               XInterface      = 1'b0,
+  parameter [31:0]            CoprocOpcodes   = '0
 ) (
   input  logic                      clk_i,
   input  logic                      rst_ni,
@@ -101,6 +103,25 @@ module cve2_id_stage #(
 
   input  logic                      lsu_addr_incr_req_i,
   input  logic [31:0]               lsu_addr_last_i,
+
+  //  Core-V eXtension Interface (CV-X-IF)
+  //  Issue Interface
+  output logic                      x_issue_valid_o,
+  input  logic                      x_issue_ready_i,
+  output cve2_pkg::x_issue_req_t    x_issue_req_o,
+  input  cve2_pkg::x_issue_resp_t   x_issue_resp_i,
+
+  // Register Interface
+  output  cve2_pkg::x_register_t    x_register_o,
+
+  // Commit Interface
+  output logic                      x_commit_valid_o,
+  output cve2_pkg::x_commit_t       x_commit_o,
+
+  // Result Interface
+  input  logic                      x_result_valid_i,
+  output logic                      x_result_ready_o,
+  input   cve2_pkg::x_result_t      x_result_i,
 
   // Interrupt signals
   input  logic                      csr_mstatus_mie_i,
@@ -243,6 +264,71 @@ module cve2_id_stage #(
   logic [31:0] alu_operand_a;
   logic [31:0] alu_operand_b;
 
+  // CV-X-IF
+  logic coproc_instr_in_dec;
+  logic stall_coproc;
+  logic coproc_done;
+
+
+  ///////////////
+  // ID-EX FSM //
+  ///////////////
+
+  typedef enum logic { FIRST_CYCLE, MULTI_CYCLE } id_fsm_e;
+  id_fsm_e id_fsm_q, id_fsm_d;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : id_pipeline_reg
+    if (!rst_ni) begin
+      id_fsm_q <= FIRST_CYCLE;
+    end else if (instr_executing) begin
+      id_fsm_q <= id_fsm_d;
+    end
+  end
+
+  if (XInterface) begin: gen_xif
+    assign coproc_done = (x_issue_valid_o & x_issue_ready_i & ~x_issue_resp_i.writeback) | (x_result_valid_i & x_result_i.we);
+ 
+    // Issue Interface
+    assign x_issue_valid_o     = instr_executing & coproc_instr_in_dec & (id_fsm_q == FIRST_CYCLE);
+    assign x_issue_req_o.instr = instr_rdata_i;
+
+    // Register Interface
+    assign x_register_o.rs[0]    = rf_rdata_a_fwd;
+    assign x_register_o.rs[1]    = rf_rdata_b_fwd;
+    assign x_register_o.rs_valid = '1;
+
+    // Commit Interface
+    assign x_commit_valid_o       = 1'b1;
+    assign x_commit_o.commit_kill = 1'b0;
+
+    // Result Interface 
+    assign x_result_ready_o = 1'b1;
+  end 
+  else begin: no_gen_xif
+    logic          unused_x_issue_ready;
+    x_issue_resp_t unused_x_issue_resp;
+    logic          unused_x_result_valid;
+    x_result_t     unused_x_result;
+
+    // Issue Interface
+    assign x_issue_valid_o      = 1'b0;
+    assign unused_x_issue_ready = x_issue_ready_i;
+    assign x_issue_req_o        = '0;
+    assign unused_x_issue_resp  = x_issue_resp_i;
+
+    // Register Interface
+    assign x_register_o = '0;
+
+    // Commit Interface
+    assign x_commit_valid_o = 1'b0;
+    assign x_commit_o       = '0;
+
+    // Result Interface
+    assign x_result_ready_o      = 1'b0;
+    assign unused_x_result_valid = x_result_valid_i;
+    assign unused_x_result       = x_result_i;
+  end
+
   /////////////
   // LSU Mux //
   /////////////
@@ -324,9 +410,10 @@ module cve2_id_stage #(
   // Register file write data mux
   always_comb begin : rf_wdata_id_mux
     unique case (rf_wdata_sel)
-      RF_WD_EX:  rf_wdata_id_o = result_ex_i;
-      RF_WD_CSR: rf_wdata_id_o = csr_rdata_i;
-      default:   rf_wdata_id_o = result_ex_i;
+      RF_WD_EX:     rf_wdata_id_o   = result_ex_i;
+      RF_WD_CSR:    rf_wdata_id_o   = csr_rdata_i;
+      RF_WD_COPROC: rf_wdata_id_o = x_result_i.data;
+      default:      rf_wdata_id_o   = result_ex_i;
     endcase
   end
 
@@ -337,7 +424,9 @@ module cve2_id_stage #(
   cve2_decoder #(
     .RV32E          (RV32E),
     .RV32M          (RV32M),
-    .RV32B          (RV32B)
+    .RV32B          (RV32B),
+    .XInterface     (XInterface),
+    .CoprocOpcodes  (CoprocOpcodes)
   ) decoder_i (
     .clk_i (clk_i),
     .rst_ni(rst_ni),
@@ -402,6 +491,10 @@ module cve2_id_stage #(
     .data_type_o          (lsu_type),
     .data_sign_extension_o(lsu_sign_ext),
 
+    // Core-V eXtension Interface (CV-X-IF)
+    .x_issue_resp_register_read_i(x_issue_resp_i.register_read),
+    .x_issue_resp_writeback_i(x_issue_resp_i.writeback),
+    .coproc_instr_in_dec_o(coproc_instr_in_dec),
     // jump/branches
     .jump_in_dec_o  (jump_in_dec),
     .branch_in_dec_o(branch_in_dec)
@@ -442,7 +535,7 @@ module cve2_id_stage #(
   // Controller //
   ////////////////
 
-  assign illegal_insn_o = instr_valid_i & (illegal_insn_dec | illegal_csr_insn_i);
+  assign illegal_insn_o = instr_valid_i & (illegal_insn_dec | illegal_csr_insn_i | (x_issue_valid_o & x_issue_ready_i & ~x_issue_resp_i.accept));
 
   cve2_controller #(
   ) controller_i (
@@ -599,21 +692,6 @@ module cve2_id_stage #(
   assign jump_set        = jump_set_raw        & ~branch_jump_set_done_q;
   assign branch_set      = branch_set_raw      & ~branch_jump_set_done_q;
 
-  ///////////////
-  // ID-EX FSM //
-  ///////////////
-
-  typedef enum logic { FIRST_CYCLE, MULTI_CYCLE } id_fsm_e;
-  id_fsm_e id_fsm_q, id_fsm_d;
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin : id_pipeline_reg
-    if (!rst_ni) begin
-      id_fsm_q <= FIRST_CYCLE;
-    end else if (instr_executing) begin
-      id_fsm_q <= id_fsm_d;
-    end
-  end
-
   // ID/EX stage can be in two states, FIRST_CYCLE and MULTI_CYCLE. An instruction enters
   // MULTI_CYCLE if it requires multiple cycles to complete regardless of stalls and other
   // considerations. An instruction may be held in FIRST_CYCLE if it's unable to begin executing
@@ -626,6 +704,8 @@ module cve2_id_stage #(
     stall_jump              = 1'b0;
     stall_branch            = 1'b0;
     stall_alu               = 1'b0;
+    stall_coproc            = 1'b0;
+    stall_coproc            = 1'b0;
     branch_set_raw_d        = 1'b0;
     jump_set_raw            = 1'b0;
     perf_branch_o           = 1'b0;
@@ -673,6 +753,13 @@ module cve2_id_stage #(
               id_fsm_d      = MULTI_CYCLE;
               rf_we_raw     = 1'b0;
             end
+            coproc_instr_in_dec: begin
+              if (x_issue_ready_i && x_issue_resp_i.writeback) begin
+                id_fsm_d             = MULTI_CYCLE;
+              end
+              stall_coproc = ~x_issue_ready_i ||  x_issue_resp_i.writeback; 
+              rf_we_raw  = 1'b0;
+            end
             default: begin
               id_fsm_d      = FIRST_CYCLE;
             end
@@ -690,6 +777,7 @@ module cve2_id_stage #(
             stall_multdiv   = multdiv_en_dec;
             stall_branch    = branch_in_dec;
             stall_jump      = jump_in_dec;
+            stall_coproc    = coproc_instr_in_dec;
           end
         end
 
@@ -700,13 +788,16 @@ module cve2_id_stage #(
     end
   end
 
+
+
+
   `ASSERT(StallIDIfMulticycle, (id_fsm_q == FIRST_CYCLE) & (id_fsm_d == MULTI_CYCLE) |-> stall_id)
 
 
   // Stall ID/EX stage for reason that relates to instruction in ID/EX, update assertion below if
   // modifying this.
   assign stall_id = stall_mem | stall_multdiv | stall_jump | stall_branch |
-                      stall_alu;
+                      stall_alu | stall_coproc;
 
   // Generally illegal instructions have no reason to stall, however they must still stall waiting
   // for outstanding memory requests so exceptions related to them take priority over the illegal
@@ -723,7 +814,7 @@ module cve2_id_stage #(
   // Used by ALU to access RS3 if ternary instruction.
   assign instr_first_cycle_id_o = instr_first_cycle;
 
-    assign multicycle_done = lsu_req_dec ? lsu_resp_valid_i : ex_valid_i;
+    assign multicycle_done = lsu_req_dec ? lsu_resp_valid_i : (coproc_instr_in_dec ? coproc_done : ex_valid_i);
 
     assign data_req_allowed = instr_first_cycle;
 
@@ -786,7 +877,8 @@ module cve2_id_stage #(
       OP_A_IMM})
   `ASSERT(IbexRegfileWdataSelValid, instr_valid_i |-> rf_wdata_sel inside {
       RF_WD_EX,
-      RF_WD_CSR})
+      RF_WD_CSR,
+      RF_WD_COPROC})
   `ASSERT_KNOWN(IbexWbStateKnown, id_fsm_q)
 
   // Branch decision must be valid when jumping.
@@ -803,7 +895,7 @@ module cve2_id_stage #(
 
   // Multicycle enable signals must be unique.
   `ASSERT(IbexMulticycleEnableUnique,
-      $onehot0({lsu_req_dec, multdiv_en_dec, branch_in_dec, jump_in_dec}))
+      $onehot0({lsu_req_dec, multdiv_en_dec, branch_in_dec, jump_in_dec, coproc_instr_in_dec}))
 
   // Duplicated instruction flops must match
   // === as DV environment can produce instructions with Xs in, so must use precise match that

--- a/rtl/cve2_pkg.sv
+++ b/rtl/cve2_pkg.sv
@@ -260,9 +260,10 @@ package cve2_pkg;
   } imm_b_sel_e;
 
   // Regfile write data selection
-  typedef enum logic {
+  typedef enum logic[1:0] {
     RF_WD_EX,
-    RF_WD_CSR
+    RF_WD_CSR,
+    RF_WD_COPROC
   } rf_wd_sel_e;
 
   //////////////
@@ -653,6 +654,58 @@ package cve2_pkg;
     rvfi_csr_elmt_t pmpaddr14;
     rvfi_csr_elmt_t pmpaddr15;
   } rvfi_csr_t;
+
+  // CV-X-IF
+  parameter int unsigned X_NUM_RS       = 2;
+  parameter int unsigned X_ID_WIDTH     = 4;
+  parameter int unsigned X_RFR_WIDTH    = 32;
+  parameter int unsigned X_RFW_WIDTH    = 32;
+  parameter int unsigned X_HARTID_WIDTH = 1;
+  parameter int unsigned X_DUAL_READ    = 0;
+  parameter int unsigned X_DUAL_WRITE   = 0;
+
+  typedef logic [X_NUM_RS+X_DUAL_READ-1:0] readregflags_t;
+  typedef logic [X_DUAL_WRITE:0]           writeregflags_t;
+  typedef logic [X_ID_WIDTH-1:0]           id_t;
+  typedef logic [X_HARTID_WIDTH-1:0]       hartid_t;
+
+  // Issue Interface
+  typedef struct packed {
+    logic [31:0] instr;
+    hartid_t     hartid;
+    id_t         id;
+  } x_issue_req_t;
+
+  typedef struct packed {
+    logic           accept;
+    writeregflags_t writeback;
+    readregflags_t  register_read;
+  } x_issue_resp_t;
+
+  // Register Interface
+  typedef struct packed {
+    hartid_t                              hartid;
+    id_t                                  id;
+    logic [X_NUM_RS-1:0][X_RFR_WIDTH-1:0] rs;
+    readregflags_t                        rs_valid;
+  } x_register_t;
+
+  // Commit Interface
+  typedef struct packed {
+    hartid_t hartid;  
+    id_t     id;
+    logic    commit_kill;
+  } x_commit_t;
+
+  // Result Interface
+  typedef struct packed {
+    hartid_t                hartid;
+    id_t                    id;
+    logic [X_RFW_WIDTH-1:0] data;
+    logic [4:0]             rd;
+    writeregflags_t         we;
+  } x_result_t;
+
 
 endpackage
 

--- a/rtl/cve2_top.sv
+++ b/rtl/cve2_top.sv
@@ -133,8 +133,7 @@ module cve2_top import cve2_pkg::*; #(
   localparam rv32b_e      RV32B            = RV32BNone;
 
   // CV-X-IF 
-  localparam int unsigned XInterface       = 0;
-  localparam logic[31:0]  CoprocOpcodes    = '0;
+  localparam int unsigned XInterface       = 1;
 
   // Clock signals
   logic                        clk;
@@ -185,8 +184,7 @@ module cve2_top import cve2_pkg::*; #(
     .DbgHwBreakNum    (DbgHwBreakNum),
     .DmHaltAddr       (DmHaltAddr),
     .DmExceptionAddr  (DmExceptionAddr),
-    .XInterface       (XInterface),
-    .CoprocOpcodes    (CoprocOpcodes)
+    .XInterface       (XInterface)
   ) u_cve2_core (
     .clk_i(clk),
     .rst_ni,

--- a/rtl/cve2_top.sv
+++ b/rtl/cve2_top.sv
@@ -133,7 +133,7 @@ module cve2_top import cve2_pkg::*; #(
   localparam rv32b_e      RV32B            = RV32BNone;
 
   // CV-X-IF 
-  localparam int unsigned XInterface       = 1;
+  localparam int unsigned XInterface       = 0;
 
   // Clock signals
   logic                        clk;

--- a/rtl/cve2_top.sv
+++ b/rtl/cve2_top.sv
@@ -49,6 +49,25 @@ module cve2_top import cve2_pkg::*; #(
   input  logic [31:0]                  data_rdata_i,
   input  logic                         data_err_i,
 
+  // Core-V Extension Interface (CV-X-IF)
+  // Issue Interface
+  output logic                         x_issue_valid_o,
+  input  logic                         x_issue_ready_i,
+  output x_issue_req_t                 x_issue_req_o,
+  input  x_issue_resp_t                x_issue_resp_i,
+  
+  // Register Interface   
+  output x_register_t                  x_register_o,
+  
+  // Commit Interface   
+  output logic                         x_commit_valid_o,
+  output x_commit_t                    x_commit_o,
+  
+  // Result Interface   
+  input  logic                         x_result_valid_i,
+  output logic                         x_result_ready_o,
+  input  x_result_t                    x_result_i,
+
   // Interrupt inputs
   input  logic                         irq_software_i,
   input  logic                         irq_timer_i,
@@ -113,6 +132,10 @@ module cve2_top import cve2_pkg::*; #(
   // Bit manipulation extension
   localparam rv32b_e      RV32B            = RV32BNone;
 
+  // CV-X-IF 
+  localparam int unsigned XInterface       = 0;
+  localparam logic[31:0]  CoprocOpcodes    = '0;
+
   // Clock signals
   logic                        clk;
   logic                        core_busy_d, core_busy_q;
@@ -161,7 +184,9 @@ module cve2_top import cve2_pkg::*; #(
     .DbgTriggerEn     (DbgTriggerEn),
     .DbgHwBreakNum    (DbgHwBreakNum),
     .DmHaltAddr       (DmHaltAddr),
-    .DmExceptionAddr  (DmExceptionAddr)
+    .DmExceptionAddr  (DmExceptionAddr),
+    .XInterface       (XInterface),
+    .CoprocOpcodes    (CoprocOpcodes)
   ) u_cve2_core (
     .clk_i(clk),
     .rst_ni,
@@ -186,6 +211,25 @@ module cve2_top import cve2_pkg::*; #(
     .data_wdata_o,
     .data_rdata_i,
     .data_err_i,
+
+    // Core-V Extension Interface (CV-X-IF)
+    // Issue Interface
+    .x_issue_valid_o,
+    .x_issue_ready_i,
+    .x_issue_req_o,
+    .x_issue_resp_i,
+
+    // Register Interface
+    .x_register_o,
+
+    // Commit Interface
+    .x_commit_valid_o,
+    .x_commit_o,
+
+    // Result Interface
+    .x_result_valid_i,
+    .x_result_ready_o,
+    .x_result_i,
 
     .irq_software_i,
     .irq_timer_i,

--- a/rtl/cve2_top_tracing.sv
+++ b/rtl/cve2_top_tracing.sv
@@ -44,6 +44,25 @@ module cve2_top_tracing import cve2_pkg::*; #(
   input  logic [31:0]                  data_rdata_i,
   input  logic                         data_err_i,
 
+  // Core-V Extension Interface (CV-X-IF)
+  // Issue Interface
+  output logic                         x_issue_valid_o,
+  input  logic                         x_issue_ready_i,
+  output x_issue_req_t                 x_issue_req_o,
+  input  x_issue_resp_t                x_issue_resp_i,
+  
+  // Register Interface   
+  output x_register_t                  x_register_o,
+  
+  // Commit Interface   
+  output logic                         x_commit_valid_o,
+  output x_commit_t                    x_commit_o,
+  
+  // Result Interface   
+  input  logic                         x_result_valid_i,
+  output logic                         x_result_ready_o,
+  input  x_result_t                    x_result_i,
+
   // Interrupt inputs
   input  logic                         irq_software_i,
   input  logic                         irq_timer_i,
@@ -140,6 +159,25 @@ module cve2_top_tracing import cve2_pkg::*; #(
     .data_rdata_i,
     .data_err_i,
 
+    // Core-V Extension Interface (CV-X-IF)
+    // Issue Interface
+    .x_issue_valid_o,
+    .x_issue_ready_i,
+    .x_issue_req_o,
+    .x_issue_resp_i,
+
+    // Register Interface
+    .x_register_o,
+
+    // Commit Interface
+    .x_commit_valid_o,
+    .x_commit_o,
+
+    // Result Interface
+    .x_result_valid_i,
+    .x_result_ready_o,
+    .x_result_i,
+    
     .irq_software_i,
     .irq_timer_i,
     .irq_external_i,


### PR DESCRIPTION
This pull request focuses on integrating the Core-V eXtension Interface (CV-X-IF) within the cve2 core. All CV-X-IF interfaces are included, except for the memory interface, as the documentation currently lacks details on its implementation.
