### PR TITLE
[rtl] Changed the default number of performance counters from 0 to 10…

### DIFF
--- a/rtl/cve2_core.sv
+++ b/rtl/cve2_core.sv
@@ -16,7 +16,7 @@ module cve2_core import cve2_pkg::*; #(
   parameter bit          PMPEnable         = 1'b0,
   parameter int unsigned PMPGranularity    = 0,
   parameter int unsigned PMPNumRegions     = 4,
-  parameter int unsigned MHPMCounterNum    = 0,
+  parameter int unsigned MHPMCounterNum    = 10,
   parameter int unsigned MHPMCounterWidth  = 40,
   parameter bit          RV32E             = 1'b0,
   parameter rv32m_e      RV32M             = RV32MFast,

--- a/rtl/cve2_top.sv
+++ b/rtl/cve2_top.sv
@@ -13,7 +13,7 @@
  * Top level module of the ibex RISC-V core
  */
 module cve2_top import cve2_pkg::*; #(
-  parameter int unsigned MHPMCounterNum   = 0,
+  parameter int unsigned MHPMCounterNum   = 10,
   parameter int unsigned MHPMCounterWidth = 40,
   parameter bit          RV32E            = 1'b0,
   parameter rv32m_e      RV32M            = RV32MFast,

--- a/rtl/cve2_top_tracing.sv
+++ b/rtl/cve2_top_tracing.sv
@@ -7,7 +7,7 @@
  */
 
 module cve2_top_tracing import cve2_pkg::*; #(
-  parameter int unsigned MHPMCounterNum   = 0,
+  parameter int unsigned MHPMCounterNum   = 10,
   parameter int unsigned MHPMCounterWidth = 40,
   parameter bit          RV32E            = 1'b0,
   parameter rv32m_e      RV32M            = RV32MFast,


### PR DESCRIPTION
… (#214)

 [rtl/cve2_cs_registers.sv](https://github.com/openhwgroup/cve2/blob/main/rtl/cve2_cs_registers.sv#L18) did not need to be changed as its default value was already 10
