### PR TITLE
Modification of some Debug Modules parameters into (static) signals, as part of (#269)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build output
 build
+buildsim.log
 
 # Common editor/IDE config and temporary files
 .project

--- a/doc/02_user/integration.rst
+++ b/doc/02_user/integration.rst
@@ -19,9 +19,7 @@ Instantiation Template
       .RV32E            ( 0                                ),
       .RV32M            ( cve2_pkg::RV32MFast              ),
       .RndCnstLfsrSeed  ( cve2_pkg::RndCnstLfsrSeedDefault ),
-      .RndCnstLfsrPerm  ( cve2_pkg::RndCnstLfsrPermDefault ),
-      .DmHaltAddr       ( 32'h1A110800                     ),
-      .DmExceptionAddr  ( 32'h1A110808                     )
+      .RndCnstLfsrPerm  ( cve2_pkg::RndCnstLfsrPermDefault )
   ) u_top (
       // Clock and reset
       .clk_i                  (),
@@ -65,6 +63,8 @@ Instantiation Template
 
       // Debug interface
       .debug_req_i            (),
+      .dm_halt_addr_i         (),
+      .dm_exception_addr_i    (),
       .crash_dump_o           (),
 
       // Special control signals
@@ -92,10 +92,6 @@ Parameters
 |                              |                     |            | "cve2_pkg::RV32MSlow": Slow multi-cycle multiplier, iterative divider |
 |                              |                     |            | "cve2_pkg::RV32MFast": 3-4 cycle multiplier, iterative divider        |
 |                              |                     |            | "cve2_pkg::RV32MSingleCycle": 1-2 cycle multiplier, iterative divider |
-+------------------------------+---------------------+------------+-----------------------------------------------------------------------+
-| ``DmHaltAddr``               | int                 | 0x1A110800 | Address to jump to when entering Debug Mode                           |
-+------------------------------+---------------------+------------+-----------------------------------------------------------------------+
-| ``DmExceptionAddr``          | int                 | 0x1A110808 | Address to jump to when an exception occurs while in Debug Mode       |
 +------------------------------+---------------------+------------+-----------------------------------------------------------------------+
 
 Any parameter marked *EXPERIMENTAL* when enabled is not verified to the same standard as the rest of the Ibex core.

--- a/doc/03_reference/debug.rst
+++ b/doc/03_reference/debug.rst
@@ -3,12 +3,12 @@
 Debug Support
 =============
 
-Ibex offers support for execution-based debug according to the `RISC-V Debug Specification <https://riscv.org/specifications/debug-specification/>`_, version 0.13.
+CVE2 offers support for execution-based debug according to the `RISC-V Debug Specification <https://riscv.org/specifications/debug-specification/>`_, version 0.13.
 
 
 .. note::
 
-   Debug support in Ibex is only one of the components needed to build a System on Chip design with run-control debug support (think "the ability to attach GDB to a core over JTAG").
+   Debug support in CVE2 is only one of the components needed to build a System on Chip design with run-control debug support (think "the ability to attach GDB to a core over JTAG").
    Additionally, a Debug Module and a Debug Transport Module, compliant with the RISC-V Debug Specification, are needed.
 
    A supported open source implementation of these building blocks can be found in the `RISC-V Debug Support for PULP Cores IP block <https://github.com/pulp-platform/riscv-dbg/>`_.
@@ -18,29 +18,22 @@ Ibex offers support for execution-based debug according to the `RISC-V Debug Spe
 Interface
 ---------
 
-+-----------------+-----------+-----------------------------+
-| Signal          | Direction | Description                 |
-+=================+===========+=============================+
-| ``debug_req_i`` | input     | Request to enter Debug Mode |
-+-----------------+-----------+-----------------------------+
++----------------------------------+---------------------+--------------------------------------------------------------------------------------+
+| Signal                           | Direction           | Description                                                                          |
++==================================+=====================+======================================================================================+
+| ``debug_req_i``                  | input               | Request to enter Debug Mode                                                          |
++----------------------------------+---------------------+--------------------------------------------------------------------------------------+
+| ``dm_halt_addr_i``               | input               | Address to jump to when entering Debug Mode (default 0x1A110800)                     |
++----------------------------------+---------------------+--------------------------------------------------------------------------------------+
+| ``dm_exception_addr_i``          | input               | Address to jump to when an exception occurs while in Debug Mode (default 0x1A110808) |
++----------------------------------+---------------------+--------------------------------------------------------------------------------------+
 
 ``debug_req_i`` is the "debug interrupt", issued by the debug module when the core should enter Debug Mode.
-
-Parameters
-----------
-
-+---------------------+-----------------------------------------------------------------+
-| Parameter           | Description                                                     |
-+=====================+=================================================================+
-| ``DmHaltAddr``      | Address to jump to when entering Debug Mode                     |
-+---------------------+-----------------------------------------------------------------+
-| ``DmExceptionAddr`` | Address to jump to when an exception occurs while in Debug Mode |
-+---------------------+-----------------------------------------------------------------+
 
 Core Debug Registers
 --------------------
 
-Ibex implements four core debug registers, namely :ref:`csr-dcsr`, :ref:`csr-dpc`, and two debug scratch registers.
+CVE2 implements four core debug registers, namely :ref:`csr-dcsr`, :ref:`csr-dpc`, and two debug scratch registers.
 Debug trigger registers are available. See :ref:`csr-tselect`, :ref:`csr-tdata1` and :ref:`csr-tdata2` for details.
 All those registers are accessible from Debug Mode only.
 If software tries to access them without the core being in Debug Mode, an illegal instruction exception is triggered.

--- a/dv/riscv_compliance/rtl/cve2_riscv_compliance.sv
+++ b/dv/riscv_compliance/rtl/cve2_riscv_compliance.sv
@@ -1,11 +1,12 @@
 // Copyright lowRISC contributors.
+// Copyright 2025 OpenHW Group.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Ibex simulation to run the RISC-V compliance test on
+ * CVE2 simulation to run the RISC-V compliance test on
  *
- * This is a toplevel wrapper for Ibex with helpers to run the RISC-V compliance
+ * This is a toplevel wrapper for CVE2 with helpers to run the RISC-V compliance
  * test. It is designed for Verilator, but should equally work for other
  * simulators (if the top-level clk and rst ports are replaced with a generated
  * clock).
@@ -121,9 +122,7 @@ module cve2_riscv_compliance (
       .ICache          (ICache          ),
       .ICacheECC       (ICacheECC       ),
       .SecureIbex      (SecureIbex      ),
-      .ICacheScramble  (ICacheScramble  ),
-      .DmHaltAddr      (32'h00000000    ),
-      .DmExceptionAddr (32'h00000000    )
+      .ICacheScramble  (ICacheScramble  )
     ) u_top (
       .clk_i                  (clk_sys                ),
       .rst_ni                 (rst_sys_n              ),
@@ -168,6 +167,8 @@ module cve2_riscv_compliance (
       .scramble_req_o         (                       ),
 
       .debug_req_i            ('b0                    ),
+      .dm_halt_addr_i         (32'h00000000           ),
+      .dm_exception_addr_i    (32'h00000000           ),
       .crash_dump_o           (                       ),
       .double_fault_seen_o    (                       ),
 

--- a/rtl/cve2_core.sv
+++ b/rtl/cve2_core.sv
@@ -10,7 +10,7 @@
 `include "prim_assert.sv"
 
 /**
- * Top level module of the ibex RISC-V core
+ * Top level module of the CVE2 RISC-V core
  */
 module cve2_core import cve2_pkg::*; #(
   parameter bit          PMPEnable         = 1'b0,
@@ -22,9 +22,7 @@ module cve2_core import cve2_pkg::*; #(
   parameter rv32m_e      RV32M             = RV32MFast,
   parameter rv32b_e      RV32B             = RV32BNone,
   parameter bit          DbgTriggerEn      = 1'b0,
-  parameter int unsigned DbgHwBreakNum     = 1,
-  parameter int unsigned DmHaltAddr        = 32'h1A110800,
-  parameter int unsigned DmExceptionAddr   = 32'h1A110808
+  parameter int unsigned DbgHwBreakNum     = 1
 ) (
   // Clock and Reset
   input  logic                         clk_i,
@@ -64,6 +62,8 @@ module cve2_core import cve2_pkg::*; #(
 
   // Debug Interface
   input  logic                         debug_req_i,
+  input  logic [31:0]                  dm_halt_addr_i,
+  input  logic [31:0]                  dm_exception_addr_i,
   output crash_dump_t                  crash_dump_o,
   // SEC_CM: EXCEPTION.CTRL_FLOW.LOCAL_ESC
   // SEC_CM: EXCEPTION.CTRL_FLOW.GLOBAL_ESC
@@ -284,10 +284,7 @@ module cve2_core import cve2_pkg::*; #(
   // IF stage //
   //////////////
 
-  cve2_if_stage #(
-    .DmHaltAddr       (DmHaltAddr),
-    .DmExceptionAddr  (DmExceptionAddr)
-  ) if_stage_i (
+  cve2_if_stage if_stage_i (
     .clk_i (clk_i),
     .rst_ni(rst_ni),
 
@@ -333,6 +330,10 @@ module cve2_core import cve2_pkg::*; #(
     .csr_mtvec_i     (csr_mtvec),  // trap-vector base address
     .csr_mtvec_init_o(csr_mtvec_init),
 
+    // debug signals
+    .dm_halt_addr_i       (dm_halt_addr_i),
+    .dm_exception_addr_i  (dm_exception_addr_i),
+
     // pipeline stalls
     .id_in_ready_i(id_in_ready),
 
@@ -343,7 +344,7 @@ module cve2_core import cve2_pkg::*; #(
   // available
   assign perf_iside_wait = id_in_ready & ~instr_valid_id;
 
-  // For non secure Ibex only the bottom bit of fetch enable is considered
+  // For non secure CVE2 only the bottom bit of fetch enable is considered
   assign instr_req_gated = instr_req_int;
 
   //////////////
@@ -994,7 +995,7 @@ module cve2_core import cve2_pkg::*; #(
 
   assign rvfi_stage_order_d = rvfi_stage_order[0] + 64'd1;
 
-  // For interrupts and debug Ibex will take the relevant trap as soon as whatever instruction in ID
+  // For interrupts and debug CVE2 will take the relevant trap as soon as whatever instruction in ID
   // finishes or immediately if the ID stage is empty. The rvfi_ext interface provides the DV
   // environment with information about the irq/debug_req/nmi state that applies to a particular
   // instruction.

--- a/rtl/cve2_core.sv
+++ b/rtl/cve2_core.sv
@@ -16,7 +16,7 @@ module cve2_core import cve2_pkg::*; #(
   parameter bit          PMPEnable         = 1'b0,
   parameter int unsigned PMPGranularity    = 0,
   parameter int unsigned PMPNumRegions     = 4,
-  parameter int unsigned MHPMCounterNum    = 0,
+  parameter int unsigned MHPMCounterNum    = 10,
   parameter int unsigned MHPMCounterWidth  = 40,
   parameter bit          RV32E             = 1'b0,
   parameter rv32m_e      RV32M             = RV32MFast,

--- a/rtl/cve2_if_stage.sv
+++ b/rtl/cve2_if_stage.sv
@@ -1,5 +1,6 @@
 // Copyright lowRISC contributors.
 // Copyright 2018 ETH Zurich and University of Bologna, see also CREDITS.md.
+// Copyright 2025 OpenHW Group.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,10 +13,7 @@
 
 `include "prim_assert.sv"
 
-module cve2_if_stage import cve2_pkg::*; #(
-  parameter int unsigned DmHaltAddr        = 32'h1A110800,
-  parameter int unsigned DmExceptionAddr   = 32'h1A110808
-) (
+module cve2_if_stage import cve2_pkg::*; (
   input  logic                         clk_i,
   input  logic                         rst_ni,
 
@@ -67,6 +65,10 @@ module cve2_if_stage import cve2_pkg::*; #(
                                                                 // the debug request
   input  logic [31:0]                 csr_mtvec_i,              // base PC to jump to on exception
   output logic                        csr_mtvec_init_o,         // tell CS regfile to init mtvec
+
+  // debug signals
+  input logic [31:0]                  dm_halt_addr_i,           // default 32'h1A110800
+  input logic [31:0]                  dm_exception_addr_i,      // default 32'h1A110808
 
   // pipeline stall
   input  logic                        id_in_ready_i,            // ID stage is ready for new instr
@@ -123,8 +125,8 @@ module cve2_if_stage import cve2_pkg::*; #(
     unique case (exc_pc_mux_i)
       EXC_PC_EXC:     exc_pc = { csr_mtvec_i[31:8], 8'h00              };
       EXC_PC_IRQ:     exc_pc = { csr_mtvec_i[31:8], irq_id[5:0], 2'b00 };
-      EXC_PC_DBD:     exc_pc = DmHaltAddr;
-      EXC_PC_DBG_EXC: exc_pc = DmExceptionAddr;
+      EXC_PC_DBD:     exc_pc = dm_halt_addr_i;
+      EXC_PC_DBG_EXC: exc_pc = dm_exception_addr_i;
       default:        exc_pc = { csr_mtvec_i[31:8], 8'h00              };
     endcase
   end

--- a/rtl/cve2_top.sv
+++ b/rtl/cve2_top.sv
@@ -1,5 +1,6 @@
 // Copyright lowRISC contributors.
 // Copyright 2018 ETH Zurich and University of Bologna, see also CREDITS.md.
+// Copyright 2025 OpenHW Group.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,15 +11,13 @@
 `include "prim_assert.sv"
 
 /**
- * Top level module of the ibex RISC-V core
+ * Top level module of the CVE2 RISC-V core
  */
 module cve2_top import cve2_pkg::*; #(
   parameter int unsigned MHPMCounterNum   = 10,
   parameter int unsigned MHPMCounterWidth = 40,
   parameter bit          RV32E            = 1'b0,
-  parameter rv32m_e      RV32M            = RV32MFast,
-  parameter int unsigned DmHaltAddr       = 32'h1A110800,
-  parameter int unsigned DmExceptionAddr  = 32'h1A110808
+  parameter rv32m_e      RV32M            = RV32MFast
 ) (
   // Clock and Reset
   input  logic                         clk_i,
@@ -58,6 +57,8 @@ module cve2_top import cve2_pkg::*; #(
 
   // Debug Interface
   input  logic                         debug_req_i,
+  input  logic [31:0]                  dm_halt_addr_i,
+  input  logic [31:0]                  dm_exception_addr_i,
   output crash_dump_t                  crash_dump_o,
 
   // RISC-V Formal Interface
@@ -107,7 +108,7 @@ module cve2_top import cve2_pkg::*; #(
   localparam int unsigned PMPNumRegions    = 4;
 
   // Trigger support
-  localparam bit          DbgTriggerEn     = 1'b1;
+  localparam bit          DbgTriggerEn     = 1'b1; // DEBUG_TRIGGER_EN in CVE4
   localparam int unsigned DbgHwBreakNum    = 1;
 
   // Bit manipulation extension
@@ -159,9 +160,7 @@ module cve2_top import cve2_pkg::*; #(
     .RV32M            (RV32M),
     .RV32B            (RV32B),
     .DbgTriggerEn     (DbgTriggerEn),
-    .DbgHwBreakNum    (DbgHwBreakNum),
-    .DmHaltAddr       (DmHaltAddr),
-    .DmExceptionAddr  (DmExceptionAddr)
+    .DbgHwBreakNum    (DbgHwBreakNum)
   ) u_cve2_core (
     .clk_i(clk),
     .rst_ni,
@@ -195,6 +194,8 @@ module cve2_top import cve2_pkg::*; #(
     .irq_pending_o(irq_pending),
 
     .debug_req_i,
+    .dm_halt_addr_i,
+    .dm_exception_addr_i,
     .crash_dump_o,
 
 `ifdef RVFI

--- a/rtl/cve2_top.sv
+++ b/rtl/cve2_top.sv
@@ -13,7 +13,7 @@
  * Top level module of the ibex RISC-V core
  */
 module cve2_top import cve2_pkg::*; #(
-  parameter int unsigned MHPMCounterNum   = 0,
+  parameter int unsigned MHPMCounterNum   = 10,
   parameter int unsigned MHPMCounterWidth = 40,
   parameter bit          RV32E            = 1'b0,
   parameter rv32m_e      RV32M            = RV32MFast,

--- a/rtl/cve2_top_tracing.sv
+++ b/rtl/cve2_top_tracing.sv
@@ -7,7 +7,7 @@
  */
 
 module cve2_top_tracing import cve2_pkg::*; #(
-  parameter int unsigned MHPMCounterNum   = 0,
+  parameter int unsigned MHPMCounterNum   = 10,
   parameter int unsigned MHPMCounterWidth = 40,
   parameter bit          RV32E            = 1'b0,
   parameter rv32m_e      RV32M            = RV32MFast,

--- a/rtl/cve2_top_tracing.sv
+++ b/rtl/cve2_top_tracing.sv
@@ -1,4 +1,5 @@
 // Copyright lowRISC contributors.
+// Copyright 2025 OpenHW Group.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,9 +11,7 @@ module cve2_top_tracing import cve2_pkg::*; #(
   parameter int unsigned MHPMCounterNum   = 10,
   parameter int unsigned MHPMCounterWidth = 40,
   parameter bit          RV32E            = 1'b0,
-  parameter rv32m_e      RV32M            = RV32MFast,
-  parameter int unsigned DmHaltAddr       = 32'h1A110800,
-  parameter int unsigned DmExceptionAddr  = 32'h1A110808
+  parameter rv32m_e      RV32M            = RV32MFast
 ) (
   // Clock and Reset
   input  logic                         clk_i,
@@ -53,6 +52,8 @@ module cve2_top_tracing import cve2_pkg::*; #(
 
   // Debug Interface
   input  logic                         debug_req_i,
+  input  logic [31:0]                  dm_halt_addr_i,
+  input  logic [31:0]                  dm_exception_addr_i,
   output crash_dump_t                  crash_dump_o,
 
   // CPU Control Signals
@@ -110,9 +111,7 @@ module cve2_top_tracing import cve2_pkg::*; #(
     .MHPMCounterNum   ( MHPMCounterNum   ),
     .MHPMCounterWidth ( MHPMCounterWidth ),
     .RV32E            ( RV32E            ),
-    .RV32M            ( RV32M            ),
-    .DmHaltAddr       ( DmHaltAddr       ),
-    .DmExceptionAddr  ( DmExceptionAddr  )
+    .RV32M            ( RV32M            )
   ) u_cve2_top (
     .clk_i,
     .rst_ni,
@@ -147,6 +146,8 @@ module cve2_top_tracing import cve2_pkg::*; #(
     .irq_nm_i,
 
     .debug_req_i,
+    .dm_halt_addr_i,
+    .dm_exception_addr_i,
     .crash_dump_o,
 
     .rvfi_valid,


### PR DESCRIPTION
Modification of some Debug Modules parameters into (static) signals, as part of the task to 
uniformize the CVE2 interface IO with the CVE4,  #269  In summary:

* The Debug halt and exception addresses were transformed from parameters (`DmHaltAddr`,  `DmExceptionAddr`) into signals (dm_halt_addr_i, dm_exception_addr_i) , matching their equivalents on the CVE4
* `DbgTriggerEn` was kept, but a reference comment to CVE4's `DbgTriggerEn`
* `DbgHwBreakNum`, the number of hardware breakpoints supported, has no equivalent on the CVE4, so I kept it.

Additionally:
* Added a buildsim.log to the gitignore, as it was generated by some make targets
* Modified the reference from the IBEX to CVE2 on some comments of the already modified files, when necessary.
* This PR includes the commit to extend the Performance counters from 0 to 10, _part_ of #214 
