### PR TITLE
Fix remaining sec inconsistency regarding the X-IF addition

### DIFF
--- a/rtl/cve2_decoder.sv
+++ b/rtl/cve2_decoder.sv
@@ -51,7 +51,7 @@ module cve2_decoder #(
   output logic [31:0]           zimm_rs1_type_o,
 
   // register file
-  output cve2_pkg::rf_wd_sel_e     rf_wdata_sel_o,   // RF write data selection
+  output logic [XInterface:0]      rf_wdata_sel_o,   // RF write data 
   output logic                     rf_we_o,          // write enable for regfile
   output logic [4:0]               rf_raddr_a_o,
   output logic [4:0]               rf_raddr_b_o,
@@ -660,7 +660,7 @@ module cve2_decoder #(
     // insufficient privileges), or when accessing non-available registers in RV32E,
     // these cases are not handled here
     if (illegal_insn) begin
-      // rf_we           = 1'b0;
+      rf_we           &= XInterface;
       data_req_o      = 1'b0;
       data_we_o       = 1'b0;
       jump_in_dec_o   = 1'b0;

--- a/rtl/cve2_decoder.sv
+++ b/rtl/cve2_decoder.sv
@@ -660,6 +660,7 @@ module cve2_decoder #(
     // insufficient privileges), or when accessing non-available registers in RV32E,
     // these cases are not handled here
     if (illegal_insn) begin
+      // rf_we           = 1'b0;
       data_req_o      = 1'b0;
       data_we_o       = 1'b0;
       jump_in_dec_o   = 1'b0;

--- a/rtl/cve2_decoder.sv
+++ b/rtl/cve2_decoder.sv
@@ -51,7 +51,7 @@ module cve2_decoder #(
   output logic [31:0]           zimm_rs1_type_o,
 
   // register file
-  output logic [XInterface:0]      rf_wdata_sel_o,   // RF write data 
+  output logic [XInterface:0]      rf_wdata_sel_o,   // RF write data selection
   output logic                     rf_we_o,          // write enable for regfile
   output logic [4:0]               rf_raddr_a_o,
   output logic [4:0]               rf_raddr_b_o,

--- a/rtl/cve2_id_stage.sv
+++ b/rtl/cve2_id_stage.sv
@@ -418,12 +418,19 @@ module cve2_id_stage #(
 
   // Register file write data mux
   always_comb begin : rf_wdata_id_mux
-    unique case (rf_wdata_sel)
-      RF_WD_EX:     rf_wdata_id_o   = result_ex_i;
-      RF_WD_CSR:    rf_wdata_id_o   = csr_rdata_i;
-      RF_WD_COPROC: rf_wdata_id_o   = x_result_i.data;
-      default:      rf_wdata_id_o   = result_ex_i;
-    endcase
+    if (XInterface)
+      unique case (rf_wdata_sel)
+        RF_WD_EX:     rf_wdata_id_o   = result_ex_i;
+        RF_WD_CSR:    rf_wdata_id_o   = csr_rdata_i;
+        RF_WD_COPROC: rf_wdata_id_o   = x_result_i.data;
+        default:      rf_wdata_id_o   = result_ex_i;
+      endcase
+    else
+      unique case (rf_wdata_sel)
+        RF_WD_EX:     rf_wdata_id_o   = result_ex_i;
+        RF_WD_CSR:    rf_wdata_id_o   = csr_rdata_i;
+        default:      rf_wdata_id_o   = result_ex_i;
+      endcase
   end
 
   /////////////
@@ -711,7 +718,6 @@ module cve2_id_stage #(
     stall_branch            = 1'b0;
     stall_alu               = 1'b0;
     stall_coproc            = 1'b0;
-    stall_coproc            = 1'b0;
     branch_set_raw_d        = 1'b0;
     jump_set_raw            = 1'b0;
     perf_branch_o           = 1'b0;
@@ -800,7 +806,7 @@ module cve2_id_stage #(
             stall_multdiv   = multdiv_en_dec;
             stall_branch    = branch_in_dec;
             stall_jump      = jump_in_dec;
-            stall_coproc    = illegal_insn_dec;
+            stall_coproc    = XInterface & illegal_insn_dec;
           end
         end
 

--- a/rtl/cve2_pkg.sv
+++ b/rtl/cve2_pkg.sv
@@ -260,10 +260,10 @@ package cve2_pkg;
   } imm_b_sel_e;
 
   // Regfile write data selection
-  typedef enum logic[1:0] {
+  typedef enum {
     RF_WD_EX,
     RF_WD_CSR,
-    RF_WD_COPROC
+    RF_WD_COPROC // Only used when XInterface = 1
   } rf_wd_sel_e;
 
   //////////////

--- a/scripts/sec/sec.sh
+++ b/scripts/sec/sec.sh
@@ -100,13 +100,21 @@ elif [[ "${target_tool}" == "mentor" ]]; then
 
 elif [[ "${target_tool}" == "yosys" ]]; then
     echo "Using Yosys EQY"
-    eqy -f yosys/sec.eqy -j $(($(nproc)/2)) -d ${report_dir} &> ${report_dir}/output.yosys.log
+
+    if ! [ -x "$(command -v eqy)" ]; then
+        echo "Yosys EQY (eqy) could not be found"
+        exit 1
+    fi
+
+    eqy -f yosys/sec.eqy -j $(($(nproc)/2)) -d ${report_dir} &> /dev/null
+    mv ${report_dir}/logfile.txt ${report_dir}/output.yosys.log
     rm yosys/golden_io.txt
 
     if [ -f "${report_dir}/PASS" ]; then 
         RESULT=0
     elif [ -f "${report_dir}/FAIL" ]; then 
         RESULT=1
+        echo "Check ${report_dir}/output.yosys.log"
     else
         echo "Failed to run Yosys EQY"
         exit 1


### PR DESCRIPTION
* I reviewed #290 and found out that what the main issue still missing was that the signal rf_wdata_sel, coming out of the cve2_decoder, had its length changed from 1 to 2 bits in order to allow the RF_WD_COPROC value. 

The problem is that this was made independently if the X-IF interface is enabled or not, so I set it to be 1 bit when XInterface is 0. 

* Regarding the reset on the rf_we, as done on the original core. I just simplified the logic on #290
* Additionally, I modified the assertion that checks the value of rf_wdata_sel after instr_valid_i is set, to comprise its valid states dependent on the XInterface (presence of X-IF). i.e. to not consider an RF_WD_COPROC value if there is no X-IF.