### PR TITLE
Update Read the Docs OS version to Ubuntu 24.04

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-24.04"
   tools:
     python: "3.9"
 


### PR DESCRIPTION
Read The Docs announced the deprecation of the Ubuntu 20.04 LTS build image (build.os: ubuntu-20.04). This PR updates to 24.04