### PR TITLE
[fix] update fatal call in cve2_top_tracing.sv

### DIFF
--- a/rtl/cve2_top_tracing.sv
+++ b/rtl/cve2_top_tracing.sv
@@ -84,7 +84,7 @@ module cve2_top_tracing import cve2_pkg::*; #(
 
   // cve2_tracer relies on the signals from the RISC-V Formal Interface
   `ifndef RVFI
-    $fatal("Fatal error: RVFI needs to be defined globally.");
+    $fatal(1, "Fatal error: RVFI needs to be defined globally.");
   `endif
 
   logic        rvfi_valid;


### PR DESCRIPTION
Simple update of `$fatal` call to include an exit code as the first argument.

closes #321