### PR TITLE
Add missing CV-X-IF register interface signals

### DIFF
--- a/doc/02_user/integration.rst
+++ b/doc/02_user/integration.rst
@@ -58,6 +58,8 @@ Instantiation Template
       .x_issue_resp_i         (),
 
       // Register Interface
+      .x_register_valid_o     (),
+      .x_register_ready_i     (),
       .x_register_o           (),
 
       // Commit Interface

--- a/dv/riscv_compliance/rtl/cve2_riscv_compliance.sv
+++ b/dv/riscv_compliance/rtl/cve2_riscv_compliance.sv
@@ -142,6 +142,8 @@ module cve2_riscv_compliance (
       .x_issue_req_o          (                       ),
       .x_issue_resp_i         ('0                     ),
 
+      .x_register_valid_o     (                       ),
+      .x_register_ready_i     ('0                     ),
       .x_register_o           (                       ),
 
       .x_commit_valid_o       (                       ),

--- a/rtl/cve2_core.sv
+++ b/rtl/cve2_core.sv
@@ -62,6 +62,8 @@ module cve2_core import cve2_pkg::*; #(
   input  x_issue_resp_t                x_issue_resp_i,
 
   // Register Interface
+  output logic                         x_register_valid_o,
+  input  logic                         x_register_ready_i,
   output x_register_t                  x_register_o,
 
   // Commit Interface
@@ -473,6 +475,8 @@ module cve2_core import cve2_pkg::*; #(
     .x_issue_resp_i(x_issue_resp_i),
 
     // Register Interface
+    .x_register_valid_o(x_register_valid_o),
+    .x_register_ready_i(x_register_ready_i),
     .x_register_o(x_register_o),
 
     // Commit Interface

--- a/rtl/cve2_id_stage.sv
+++ b/rtl/cve2_id_stage.sv
@@ -113,6 +113,8 @@ module cve2_id_stage #(
   input  cve2_pkg::x_issue_resp_t   x_issue_resp_i,
 
   // Register Interface
+  output logic                      x_register_valid_o,
+  input  logic                      x_register_ready_i,
   output  cve2_pkg::x_register_t    x_register_o,
 
   // Commit Interface
@@ -274,6 +276,7 @@ module cve2_id_stage #(
   // CV-X-IF
   logic stall_coproc;
   logic scoreboard_busy;
+  logic unused_x_register_ready;
 
   ///////////////
   // ID-EX FSM //
@@ -300,21 +303,21 @@ module cve2_id_stage #(
 
     logic scoreboard_free;
 
-    // The cve2 can issue up to X_INSTR_INFLIGHT instructions over the X-IF 
+    // The cve2 can issue up to X_INSTR_INFLIGHT instructions over the X-IF
     // without waiting for their completion.
     //
-    // Each issued instruction, identified by a unique ID, sets its corresponding 
-    // scoreboard bit to `1`. When the instruction completes, that bit is cleared 
+    // Each issued instruction, identified by a unique ID, sets its corresponding
+    // scoreboard bit to `1`. When the instruction completes, that bit is cleared
     // back to `0`.
     //
-    // The cve2 always issues instructions in order, but the co-processor may 
+    // The cve2 always issues instructions in order, but the co-processor may
     // complete (commit) them out of order.
     //
-    // Once the scoreboard has issued the X_INSTR_INFLIGHT-th instruction, 
+    // Once the scoreboard has issued the X_INSTR_INFLIGHT-th instruction,
     // the instruction ID counter wraps around to 0.
     //
-    // If the previous instruction with ID 0 has already completed 
-    // (i.e., scoreboard[0] == 0), the cve2 can issue a new instruction with ID 0. 
+    // If the previous instruction with ID 0 has already completed
+    // (i.e., scoreboard[0] == 0), the cve2 can issue a new instruction with ID 0.
     // Otherwise, it waits for the instruction with ID 0 to finish before reusing it.
     //
     // This behavior applies similarly to all other instruction IDs.
@@ -356,12 +359,16 @@ module cve2_id_stage #(
     assign x_issue_req_o.hartid = hart_id_i;
 
     // Register Interface
+    assign x_register_valid_o      = x_issue_valid_o;
+    assign unused_x_register_ready = x_register_ready_i;
     assign x_register_o.rs[0]    = rf_rdata_a_fwd;
     assign x_register_o.rs[1]    = rf_rdata_b_fwd;
     assign x_register_o.rs[2]    = rf_rdata_c_fwd;
     assign x_register_o.rs_valid = '1;
     assign x_register_o.id       = x_instr_id_q;
     assign x_register_o.hartid   = hart_id_i;
+
+    // Commit Interface
     assign x_commit_valid_o       = x_issue_valid_o & x_issue_ready_i;
     assign x_commit_o.commit_kill = 1'b0;
     assign x_commit_o.id          = x_instr_id_q;
@@ -394,6 +401,8 @@ module cve2_id_stage #(
     assign unused_x_issue_resp  = x_issue_resp_i;
 
     // Register Interface
+    assign x_register_valid_o      = 1'b0;
+    assign unused_x_register_ready = x_register_ready_i;
     assign x_register_o = '0;
 
     // Commit Interface
@@ -978,7 +987,7 @@ module cve2_id_stage #(
         RF_WD_EX,
         RF_WD_CSR,
         RF_WD_COPROC})
-  end 
+  end
   else begin : no_gen_asserts_xif
     `ASSERT(IbexRegfileWdataSelValid, instr_valid_i |-> rf_wdata_sel inside {
         RF_WD_EX,

--- a/rtl/cve2_pkg.sv
+++ b/rtl/cve2_pkg.sv
@@ -657,14 +657,15 @@ package cve2_pkg;
   } rvfi_csr_t;
 
   // CV-X-IF
-  parameter int unsigned X_NUM_RS         = 3;
-  parameter int unsigned X_ID_WIDTH       = 4;
-  parameter int unsigned X_RFR_WIDTH      = 32;
-  parameter int unsigned X_RFW_WIDTH      = 32;
-  parameter int unsigned X_HARTID_WIDTH   = 32;
-  parameter int unsigned X_DUAL_READ      = 0;
-  parameter int unsigned X_DUAL_WRITE     = 0;
-  parameter int unsigned X_INSTR_INFLIGHT = 2**X_ID_WIDTH;
+  parameter int unsigned X_NUM_RS               = 3;
+  parameter int unsigned X_ID_WIDTH             = 4;
+  parameter int unsigned X_RFR_WIDTH            = 32;
+  parameter int unsigned X_RFW_WIDTH            = 32;
+  parameter int unsigned X_HARTID_WIDTH         = 32;
+  parameter int unsigned X_DUAL_READ            = 0;
+  parameter int unsigned X_DUAL_WRITE           = 0;
+  parameter int unsigned X_ISSUE_REGISTER_SPLIT = 0;
+  parameter int unsigned X_INSTR_INFLIGHT       = 2**X_ID_WIDTH;
 
   typedef logic [X_NUM_RS+X_DUAL_READ-1:0] readregflags_t;
   typedef logic [X_DUAL_WRITE:0]           writeregflags_t;

--- a/rtl/cve2_top.sv
+++ b/rtl/cve2_top.sv
@@ -58,6 +58,8 @@ module cve2_top import cve2_pkg::*; #(
   input  x_issue_resp_t                x_issue_resp_i,
 
   // Register Interface
+  output logic                         x_register_valid_o,
+  input  logic                         x_register_ready_i,
   output x_register_t                  x_register_o,
 
   // Commit Interface
@@ -217,6 +219,8 @@ module cve2_top import cve2_pkg::*; #(
     .x_issue_resp_i,
 
     // Register Interface
+    .x_register_valid_o,
+    .x_register_ready_i,
     .x_register_o,
 
     // Commit Interface

--- a/rtl/cve2_top_tracing.sv
+++ b/rtl/cve2_top_tracing.sv
@@ -51,6 +51,8 @@ module cve2_top_tracing import cve2_pkg::*; #(
   input  x_issue_resp_t                x_issue_resp_i,
 
   // Register Interface
+  output logic                         x_register_valid_o,
+  input  logic                         x_register_ready_i,
   output x_register_t                  x_register_o,
 
   // Commit Interface


### PR DESCRIPTION
Add missing register ACK signals to be fully compliant with the CV-X-IF v1.0 interface. [CV-X-IF Register Doc.](https://docs.openhwgroup.org/projects/openhw-group-core-v-xif/en/latest/x_ext.html#register-interface).

- **RTL changes:**
   - Add `x_register_valid_o` and `x_register_ready_i` ports in:
     - `cve2_riscv_compliance.sv`
     - `cve2_top.sv` 
     - `cve2_core.sv`
     - `cve2_id_stage.sv `

   - (`cve2_id_stage.sv`) Forward `x_issue_valid_o` to `x_register_valid_o`, since their behavior is equivalent when `X_ISSUE_REGISTER_SPLIT=0`
   - (`cve2_id_stage.sv`) Assign `x_register_ready_i` to the unused signal `unused_x_register_ready`. This assumes that when `X_ISSUE_REGISTER_SPLIT=0`, the coprocessor can process the issue and register transactions simultaneously `x_register_ready_i` = `x_issue_ready_i`.
   - (`cve2_pkg.sv`) Add fixed coprocessor configuration parameter `X_ISSUE_REGISTER_SPLIT=0`

- **Doc changes:**

  - (`integration.rst`) Update cve2 CV-X-IF interface



