### PR TITLE
Fix IEEE 1800-2012 syntax mismatch in $fatal call

### DIFF
--- a/rtl/cve2_top_tracing.sv
+++ b/rtl/cve2_top_tracing.sv
@@ -84,7 +84,7 @@ module cve2_top_tracing import cve2_pkg::*; #(
 
   // cve2_tracer relies on the signals from the RISC-V Formal Interface
   `ifndef RVFI
-    $fatal("Fatal error: RVFI needs to be defined globally.");
+  $fatal(1,"Fatal error: RVFI needs to be defined globally.");
   `endif
 
   logic        rvfi_valid;


### PR DESCRIPTION
added missing finish relation level argument '1' to the $fatal task inside cve2_top_tracing.sv to ensure compliance with modern industrial EDA compilers.