### PR TITLE
fix: pass the IEEE 1800 finish number to $fatal in cve2_top_tracing

### DIFF
--- a/rtl/cve2_top_tracing.sv
+++ b/rtl/cve2_top_tracing.sv
@@ -84,7 +84,7 @@ module cve2_top_tracing import cve2_pkg::*; #(
 
   // cve2_tracer relies on the signals from the RISC-V Formal Interface
   `ifndef RVFI
-    $fatal("Fatal error: RVFI needs to be defined globally.");
+    $fatal(1, "Fatal error: RVFI needs to be defined globally.");
   `endif
 
   logic        rvfi_valid;


### PR DESCRIPTION
## What

Change the `$fatal` call in `rtl/cve2_top_tracing.sv` from `$fatal("...")` to `$fatal(1, "...")`.

## Why

`$fatal` is an elaboration-time severity system task, and per IEEE 1800 its first argument must be the finish number (0, 1, or 2), not the message. The existing call passes the message string where the finish number is expected, which standards-strict simulators reject with "finish number argument must be numeric" (issue #321). This matches the approach confirmed by the maintainer in the issue discussion.

## How tested

Reproduced and verified with Icarus Verilog:

1. On the original line, elaboration fails: `Elaboration task $fatal() finish number argument must be numeric`.
2. After the fix, with `RVFI` undefined, the elaboration-time fatal fires cleanly and prints the message, so the fail-fast behaviour is preserved.
3. With `+define+RVFI` (the normal build), the guard is compiled out entirely, so there is no regression.

Closes #321
